### PR TITLE
Fix find_paths repeating in_root path when it exists

### DIFF
--- a/coveo-systools/coveo_systools/filesystem.py
+++ b/coveo-systools/coveo_systools/filesystem.py
@@ -47,6 +47,7 @@ def find_paths(
                       or relative:      Path('../python-folder')
                       or very specific: Path('python-folder/pyproject.toml')
         search_from: Search will start in this folder.
+                     When a file is specified, its folder is used.
                      When not specified, the current working directory is used.
         in root: Include results directly in search_from.
         in_parents: Include results in search_from's parent folders.
@@ -56,7 +57,7 @@ def find_paths(
         search_from = Path(".")
 
     if not search_from.is_dir():
-        raise FileNotFoundError(f"Cannot search from ({search_from}): not an existing directory.")
+        search_from = search_from.parent
 
     root_path: Path = search_from / path_to_find
     if in_root and root_path.exists():
@@ -103,6 +104,8 @@ def _which_git() -> Optional[Path]:
 def _find_repo_root(path: Path) -> Path:
     """internal, lru_cache implemented to work vs multiple repos (requires absolute paths)"""
     assert path.is_absolute()
+    if path.is_file():
+        path = path.parent
 
     git = _which_git()
     git_error: Optional[DetailedCalledProcessError] = None

--- a/coveo-systools/coveo_systools/filesystem.py
+++ b/coveo-systools/coveo_systools/filesystem.py
@@ -58,8 +58,9 @@ def find_paths(
     if not search_from.is_dir():
         raise FileNotFoundError(f"Cannot search from ({search_from}): not an existing directory.")
 
-    if in_root and (search_from / path_to_find).exists():
-        yield (search_from / path_to_find).resolve()
+    root_path: Path = search_from / path_to_find
+    if in_root and root_path.exists():
+        yield root_path.resolve()
 
     if in_parents:
         current = search_from.parent
@@ -72,7 +73,7 @@ def find_paths(
                 break
 
     if in_children:
-        yield from search_from.rglob(str(path_to_find))
+        yield from filter(lambda path: path != root_path, search_from.rglob(str(path_to_find)))
 
 
 def find_application(

--- a/coveo-systools/tests_systools/test_filesystem.py
+++ b/coveo-systools/tests_systools/test_filesystem.py
@@ -1,8 +1,9 @@
-import sys
+from pathlib import Path
+from typing import Iterator
 from unittest import mock
 
 import pytest
-from coveo_systools.filesystem import find_application
+from coveo_systools.filesystem import find_application, find_paths, find_repo_root
 from coveo_testing.markers import UnitTest
 
 
@@ -22,3 +23,29 @@ def test_raise_cannot_find_application() -> None:
 @UnitTest
 def test_find_application() -> None:
     assert find_application("python")
+
+
+@UnitTest
+def test_git_root() -> None:
+    git_root = find_repo_root(__file__)
+    assert (git_root / '.github').exists()
+    assert (git_root / 'coveo-systools').is_dir()
+
+
+@UnitTest
+def test_find_paths() -> None:
+    query = Path('pyproject.toml'), find_repo_root(__file__)
+
+    def _count(iterator: Iterator[Path]) -> int:
+        return len(list(iterator))
+
+    count_in_root = _count(find_paths(*query, in_root=True))
+    count_in_children = _count(find_paths(*query, in_children=True))
+    count_in_parents = _count(find_paths(*query, in_parents=True))
+
+    assert count_in_root == 1
+    assert count_in_children > 1
+    assert sum((count_in_parents, count_in_children, count_in_root)) == _count(
+        find_paths(*query, in_root=True, in_children=True, in_parents=True)
+    )
+    assert _count(find_paths(*query)) == 0

--- a/coveo-systools/tests_systools/test_filesystem.py
+++ b/coveo-systools/tests_systools/test_filesystem.py
@@ -28,13 +28,13 @@ def test_find_application() -> None:
 @UnitTest
 def test_git_root() -> None:
     git_root = find_repo_root(__file__)
-    assert (git_root / '.github').exists()
-    assert (git_root / 'coveo-systools').is_dir()
+    assert (git_root / ".github").exists()
+    assert (git_root / "coveo-systools").is_dir()
 
 
 @UnitTest
 def test_find_paths() -> None:
-    query = Path('pyproject.toml'), find_repo_root(__file__)
+    query = Path("pyproject.toml"), find_repo_root(__file__)
 
     def _count(iterator: Iterator[Path]) -> int:
         return len(list(iterator))


### PR DESCRIPTION
This fixes 2 things:

- when using in_children, match from the root would come up
- when using in_root and in_children, match from the root would come up twice