### PR TITLE
mypy config options added to mypy runner

### DIFF
--- a/coveo-stew/README.md
+++ b/coveo-stew/README.md
@@ -75,11 +75,32 @@ pytest = false
 offline-build = false
 ```
 
-The value type of these items is designed to be extensible. For instance, the pytest runner allows you to configure the markers for the ci run:
+### runner options
+
+The value type of these items is designed to be extensible.
+
+#### pytest options
 
 ```
 [tool.stew.ci]
-pytest = { marker_expression = 'not docker_tests' }
+
+# configure the markers to test
+pytest = { marker-expression = 'not docker_tests' }
+
+# disable the doctests
+pytest = { doctest-modules = False }
+```
+
+#### mypy options
+
+```
+[tool.stew.ci]
+
+# disable stew's strict mypy config (i.e.: let mypy find its config)
+mypy = { set-config = False } 
+
+# use a specific config (path relative to `pyproject.toml`'s folder)
+mypy = { set-config = "mypy.ini" }
 ```
 
 

--- a/coveo-stew/coveo_stew/ci/mypy_runner.py
+++ b/coveo-stew/coveo_stew/ci/mypy_runner.py
@@ -17,7 +17,9 @@ class MypyRunner(ContinuousIntegrationRunner):
     check_failed_exit_codes = [1]
     outputs_own_report = True
 
-    def __init__(self, *, set_config: Union[str, bool] = True, _pyproject: PythonProjectAPI) -> None:
+    def __init__(
+        self, *, set_config: Union[str, bool] = True, _pyproject: PythonProjectAPI
+    ) -> None:
         super().__init__(_pyproject=_pyproject)
         self.set_config = set_config
 
@@ -29,6 +31,7 @@ class MypyRunner(ContinuousIntegrationRunner):
         if self.set_config is True:
             return Path(pkg_resources.resource_filename("coveo_stew", "package_resources/mypy.ini"))
 
+        assert isinstance(self.set_config, str)  # mypy
         return self._pyproject.project_path / self.set_config
 
     def _find_typed_folders(self) -> Generator[Path, None, None]:
@@ -56,7 +59,6 @@ class MypyRunner(ContinuousIntegrationRunner):
         )
 
         args = [
-            PythonTool.Mypy,
             # the --python-executable switch tells mypy in which environment the imports should be followed.
             "--python-executable",
             environment.python_executable,
@@ -72,6 +74,7 @@ class MypyRunner(ContinuousIntegrationRunner):
             args.append(mypy_config)
 
         command = mypy_environment.build_command(
+            PythonTool.Mypy,
             *args,
             *extra_args,  # any extra argument provided by the caller
             *typed_folders,  # what to lint

--- a/coveo-stew/coveo_stew/discovery.py
+++ b/coveo-stew/coveo_stew/discovery.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Generator, Callable
 
 from coveo_styles.styles import echo
-from coveo_systools.filesystem import find_repo_root, find_paths, pushd
+from coveo_systools.filesystem import find_repo_root, find_paths
 
 from coveo_stew.exceptions import PythonProjectNotFound, NotAPoetryProject
 from coveo_stew.metadata.python_api import PythonFile
@@ -42,14 +42,6 @@ def discover_pyprojects(
     """
     if not path:
         path = find_repo_root(default=".")
-
-    try:
-        # is this a git repo?
-        find_repo_root(path)
-    except FileNotFoundError:
-        is_git_repo = False
-    else:
-        is_git_repo = True
 
     if exact_match and not query:
         raise PythonProjectNotFound("An exact match was requested but no query was provided.")

--- a/coveo-stew/coveo_stew/discovery.py
+++ b/coveo-stew/coveo_stew/discovery.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import Generator, Callable
 
 from coveo_styles.styles import echo
-from coveo_systools.filesystem import find_repo_root, find_paths
+from coveo_systools.filesystem import find_repo_root, find_paths, pushd
 
 from coveo_stew.exceptions import PythonProjectNotFound, NotAPoetryProject
 from coveo_stew.metadata.python_api import PythonFile
@@ -42,6 +42,14 @@ def discover_pyprojects(
     """
     if not path:
         path = find_repo_root(default=".")
+
+    try:
+        # is this a git repo?
+        find_repo_root(path)
+    except FileNotFoundError:
+        is_git_repo = False
+    else:
+        is_git_repo = True
 
     if exact_match and not query:
         raise PythonProjectNotFound("An exact match was requested but no query was provided.")

--- a/coveo-stew/pyproject.toml
+++ b/coveo-stew/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coveo-stew"
-version = "1.0.0"
+version = "1.1.0"
 description = "Opinionated python packaging and development utilities"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
This adds the `set-config` option to the mypy runner.

My use case is a project that uses the `setup.cfg` file to configure mypy. By searching a bit, i realize there's a LOT of different config locations and filenames going on. Using `{set-config = false}` will now rely on mypy's own discovery mechanism.

Slightly breaking change: we no longer search high and low for a `mypy.ini` file, per lessons learned doing that for the `pyproject.toml` file. Instead, we now offer the option of providing a path that is relative to the directory (added to readme!)