### PR TITLE
coveo-settings // Allow setting a value

### DIFF
--- a/.github/workflows/actions/publish-to-pypi/action.yml
+++ b/.github/workflows/actions/publish-to-pypi/action.yml
@@ -62,7 +62,7 @@ runs:
         echo "This release will be tagged as $TAG_NAME"
         git config user.name "github-actions"
         git config user.email "actions@users.noreply.github.com"
-        git tag --annotate --message="Automated tagging system" $TAG_NAME ${{ github.ref }}
+        git tag --annotate --message="Automated tagging system" $TAG_NAME ${{ github.sha }}
 
     - name: Push the tag
       shell: bash

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # coveo-python-oss
 
-This repository is a collection of useful, general-purpose python libraries made by Coveo.
+This repository is a collection of useful, general-purpose python libraries
+made by Coveo.
 
 
 ## Conventions and rules (aka The Boilerplate™)


### PR DESCRIPTION
There are some scenarios where it's super useful to be able to set the value globally. For instance, a lot of code will need to move the `dry_run` and `verbose` flags around if one wants to set them using a command line option.

Now you can simply set the value to "commit" it to the runtime. Then any other part of the code can import the symbol and get the value, if they need it.

