### PR TITLE
refine workflow logic

### DIFF
--- a/.github/workflows/actions/stew-ci/action.yml
+++ b/.github/workflows/actions/stew-ci/action.yml
@@ -1,5 +1,5 @@
-name: pyproject ci
-description: Launch pyproject ci on a project
+name: stew ci
+description: Launch stew ci on a project
 
 inputs:
   project-name:
@@ -15,7 +15,7 @@ runs:
       shell: bash
       run: python -m pip install --upgrade pip wheel setuptools poetry==1.1.6 --user --no-warn-script-location
 
-    - name: Run pyproject ci
+    - name: Run stew ci
       shell: bash
       working-directory: coveo-stew
       run: |

--- a/.github/workflows/coveo-example-library.yml
+++ b/.github/workflows/coveo-example-library.yml
@@ -36,8 +36,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-example-library.yml
+++ b/.github/workflows/coveo-example-library.yml
@@ -12,6 +12,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - 'coveo-example-library/**'
+      - '.github/workflows/**'
 
   workflow_dispatch: {}
 

--- a/.github/workflows/coveo-example-library.yml
+++ b/.github/workflows/coveo-example-library.yml
@@ -1,10 +1,18 @@
 name: coveo-example-library
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-example-library/**'
+      - '.github/workflows/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-example-library/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-functools.yml
+++ b/.github/workflows/coveo-functools.yml
@@ -35,8 +35,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-functools.yml
+++ b/.github/workflows/coveo-functools.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Publish to pypi
+      - name: Publish to pypi.org
         uses: ./.github/workflows/actions/publish-to-pypi
         with:
           project-name: ${{ github.workflow }}

--- a/.github/workflows/coveo-functools.yml
+++ b/.github/workflows/coveo-functools.yml
@@ -1,11 +1,19 @@
 name: coveo-functools
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-functools/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-functools/**'
+
   workflow_dispatch: {}
+
 
 jobs:
   pyprojectci:

--- a/.github/workflows/coveo-itertools.yml
+++ b/.github/workflows/coveo-itertools.yml
@@ -1,10 +1,17 @@
 name: coveo-itertools
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-itertools/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-itertools/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-itertools.yml
+++ b/.github/workflows/coveo-itertools.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-pypi-cli.yml
+++ b/.github/workflows/coveo-pypi-cli.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-pypi-cli.yml
+++ b/.github/workflows/coveo-pypi-cli.yml
@@ -1,10 +1,17 @@
 name: coveo-pypi-cli
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-pypi-cli/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-pypi-cli/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-pyproject.yml
+++ b/.github/workflows/coveo-pyproject.yml
@@ -1,10 +1,17 @@
 name: coveo-stew
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-stew/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-stew/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-settings.yml
+++ b/.github/workflows/coveo-settings.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-settings.yml
+++ b/.github/workflows/coveo-settings.yml
@@ -1,10 +1,17 @@
 name: coveo-settings
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-settings/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-settings/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-stew.yml
+++ b/.github/workflows/coveo-stew.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-styles.yml
+++ b/.github/workflows/coveo-styles.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-styles.yml
+++ b/.github/workflows/coveo-styles.yml
@@ -1,10 +1,17 @@
 name: coveo-styles
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-styles/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-styles/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-systools.yml
+++ b/.github/workflows/coveo-systools.yml
@@ -1,10 +1,17 @@
 name: coveo-systools
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-systools/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-systools/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-systools.yml
+++ b/.github/workflows/coveo-systools.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-testing-extras.yml
+++ b/.github/workflows/coveo-testing-extras.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-testing-extras.yml
+++ b/.github/workflows/coveo-testing-extras.yml
@@ -1,10 +1,17 @@
 name: coveo-testing-extras
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-testing-extras/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-testing-extras/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/coveo-testing.yml
+++ b/.github/workflows/coveo-testing.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run pyproject ci
-        uses: ./.github/workflows/actions/pyproject-ci
+      - name: Run stew ci
+        uses: ./.github/workflows/actions/stew-ci
         with:
           project-name: ${{ github.workflow }}
 

--- a/.github/workflows/coveo-testing.yml
+++ b/.github/workflows/coveo-testing.yml
@@ -1,10 +1,17 @@
 name: coveo-testing
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
   push:
     branches:
       - main
+    paths:
+      - 'coveo-testing/**'
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'coveo-testing/**'
+
   workflow_dispatch: {}
 
 jobs:

--- a/coveo-testing/README.md
+++ b/coveo-testing/README.md
@@ -17,7 +17,8 @@ This project is used as the test base for all other projects in this repository.
 
 Therefore, it cannot depend on any of them.
 
-More complex use cases may be implemented in the `coveo-testing-extras` project. That's also where you can depend on projects that depend on `coveo-testing`. 
+More complex use cases may be implemented in the `coveo-testing-extras` project. 
+That's also where you can depend on projects that depend on `coveo-testing`. 
 
 
 # pytest markers and auto-registration


### PR DESCRIPTION
The original version used "on: push" instead of "on: pull-requests". This caused each commit to be evaluated against its direct parent. So if you changed a file, it would launch the test for that commit, and never again. This can lead to green PRs even though the tests failed in a past commit.

With on: pull-request it correctly evaluates the whole thing vs its base.