### PR TITLE
fix the refresh on windows

### DIFF
--- a/coveo-stew/coveo_stew/stew.py
+++ b/coveo-stew/coveo_stew/stew.py
@@ -334,12 +334,17 @@ class PythonProject(PythonProjectAPI):
             return True
         return False
 
-    def refresh(self) -> None:
-        """Removes a virtual environment and then performs install."""
+    def refresh(self, environment: Optional[PythonEnvironment] = None) -> None:
+        """
+        Without an environment specified, the active one will be used if it exists.
+
+        - Removes the egg-info folder from the source
+        - Calls `poetry lock` if there were changes to pyproject.toml
+        - Creates/Installs/Cleans the environment with remove-untracked
+        """
         self.remove_egg_info()
-        self.poetry_run("env", "remove", "python", breakout_of_venv=True)
         self.lock_if_needed()
-        self.install()
+        self.install(environment=environment, remove_untracked=True)
 
     def lock_if_needed(self) -> bool:
         """Lock if needed, return True if ran."""


### PR DESCRIPTION
This may be a poetry bug 🤔 

On linux, it's OK (or at the least, it was OK before...) to call `poetry env remove <envname>` to remove an environment.

That "envname" is what you get by calling `poetry env list`. On windows you have to add `--full-path` else poetry complains that the environment doesn't exist 🤷🏻‍♂️ 

Anyway; in the end, poetry added `--remove-untracked` which didn't exist when `refresh()` was created. Not only it's faster (and nicer looking!) this way, but it also prevents some weird issues I had in the past, which deals with git not closing handles in files that sit in my `site-package`. That only happened to me on windows when pip-installing things from git, and the current PR will most likely fix those issues too!