### PR TITLE
validation callback

### DIFF
--- a/coveo-settings/README.md
+++ b/coveo-settings/README.md
@@ -24,7 +24,8 @@ A default (fallback) value may be specified. The fallback may be a `callable`.
 
 A validation callback may be specified for custom logic and error messages.
 
-A setting can be set as sensitive for logging purposes. When logging, use repr(setting) to get the correct representation.
+**A setting can be set as sensitive for logging purposes. When logging, use repr(setting) to get the correct representation.**
+
 
 
 ## Accessing the value

--- a/coveo-settings/README.md
+++ b/coveo-settings/README.md
@@ -18,9 +18,13 @@ When accessed, the values are automatically converted to the desired type:
 - `IntSetting` and `FloatSetting` are self-explanatory
 - `DictSetting` allows you to use JSON maps
 
-If the input cannot be converted to the value type, an `InvalidConfiguration` exception is raised.
+If the input cannot be converted to the value type, an `TypeConversionConfigurationError` exception is raised.
 
 A default (fallback) value may be specified. The fallback may be a `callable`.
+
+A validation callback may be specified for custom logic and error messages.
+
+A setting can be set as sensitive for logging purposes. When logging, use repr(setting) to get the correct representation.
 
 
 ## Accessing the value
@@ -40,10 +44,22 @@ assert use_ssl in [True, False]
 use_ssl = DATABASE_USE_SSL.value
 assert use_ssl in [True, False, None]
 
-# use "is_set" as a shorthand for "value is not None": 
+# use "is_set" to check if there is a value set for this setting; skips validation check
 if DATABASE_USE_SSL.is_set:
     use_ssl = bool(DATABASE_USE_SSL)
+
+# use "is_valid" to verify if the value passes the validation callback. implies is_set.
+if not DATABASE_USE_SSL.is_valid:
+    ...
 ```
+
+
+## Setting the value
+
+You can override the value using `setting.value = "some value"` and clear the override with `setting.value = None`. 
+Clearing the override resumes the normal behavior of the environment variables and the fallback value, if set.
+
+This is typically used as a way to propagate CLI switches globally.
 
 
 ## Loose environment key matching

--- a/coveo-settings/coveo_settings/settings.py
+++ b/coveo-settings/coveo_settings/settings.py
@@ -220,7 +220,7 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         # we are overly careful in not triggering mechanics (e.g.: _get_value()) from here.
         # value is only shown if already computed.
         value = next(
-            _ for _ in (self._cache_validated, self._last_value, "<not-evaluated>") if _ is not None
+            v for v in (self._cache_validated, self._last_value, "<not-evaluated>") if v is not None
         )
         return self._pretty_repr(value)
 

--- a/coveo-settings/coveo_settings/settings.py
+++ b/coveo-settings/coveo_settings/settings.py
@@ -37,8 +37,9 @@ from unittest.mock import patch
 
 ConfigValue = Union[str, int, float, bool, dict]
 ConfigDict = Dict[str, ConfigValue]
-T = TypeVar("T")  # pylint: disable=invalid-name
+T = TypeVar("T", str, int, float, bool, dict)
 ValidationCallback = Callable[[T], str]
+
 
 log = logging.getLogger(__name__)
 

--- a/coveo-settings/coveo_settings/settings.py
+++ b/coveo-settings/coveo_settings/settings.py
@@ -12,12 +12,12 @@ keys like `redis.host` as `REDIS_HOST`, `__REDIS...host_`, `RedisHost` or `REDIS
 
 This module contains no setters for a good reason; they're reserved for UTs!
 """
-
 import json
 import logging
 import os
 from abc import abstractmethod
 from contextlib import contextmanager
+from copy import copy
 from typing import (
     Any,
     Dict,
@@ -38,6 +38,7 @@ from unittest.mock import patch
 ConfigValue = Union[str, int, float, bool, dict]
 ConfigDict = Dict[str, ConfigValue]
 T = TypeVar("T")  # pylint: disable=invalid-name
+ValidationCallback = Callable[[T], str]
 
 log = logging.getLogger(__name__)
 
@@ -54,6 +55,10 @@ class TypeConversionConfigurationError(InvalidConfiguration):
 
 class MandatoryConfigurationError(InvalidConfiguration):
     """Thrown when a mandatory configuration value isn't set."""
+
+
+class ValidationConfigurationError(InvalidConfiguration):
+    """Thrown when a value fails a custom validation."""
 
 
 def _find_setting(*keys: str) -> Optional[ConfigValue]:
@@ -80,6 +85,11 @@ def _find_setting(*keys: str) -> Optional[ConfigValue]:
     return None
 
 
+def _no_validation(_: ConfigValue) -> Optional[str]:
+    """Default validation callback"""
+    return None
+
+
 class Setting(SupportsInt, SupportsFloat, Generic[T]):
     """
     Base class for magic type-checked settings.
@@ -102,14 +112,17 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         fallback: Optional[Union[ConfigValue, Callable[[], Optional[ConfigValue]]]] = None,
         alternate_keys: Optional[Collection[str]] = None,
         sensitive: bool = False,
+        validation: ValidationCallback = _no_validation,
     ) -> None:
         """ Initializes a setting. """
         self._key: str = key
         self._alternate_keys: Collection[str] = alternate_keys or tuple()
         self._fallback = fallback
         self._override: Optional[ConfigValue] = None
+        self._validation_callback: ValidationCallback = validation
         self._sensitive = sensitive
-        # validate fallback value, but skip callables to promote lazy evaluation
+        self._cache_validated: Optional[T] = None
+        self._last_value: Optional[ConfigValue] = None
         # cast fallback values so that it breaks on import (e.g.: during tests)
         # however, do not trigger any callables or validation to promote a just-in-time evaluation at runtime
         if fallback is not None and not callable(fallback):
@@ -124,7 +137,7 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
     def value(self) -> Optional[T]:
         """ Returns the validated value of the setting, or None when not set. """
         value = self._get_value()
-        return None if value is None else self._cast_or_raise(value)
+        return None if value is None else self._cast_and_validate(value)
 
     @value.setter
     def value(self, value: Optional[ConfigValue]) -> None:
@@ -139,8 +152,19 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
 
     @property
     def is_set(self) -> bool:
-        """ Indicates if the value is set (values with defaults are always set unless mocked). """
+        """
+        Indicates if the value is set (values with defaults are always set unless mocked).
+        This doesn't mean the value is valid.
+        """
         return self._get_value() is not None
+
+    @property
+    def is_valid(self) -> bool:
+        """ True if value is set and valid. """
+        try:
+            return self.value is not None
+        except InvalidConfiguration:
+            return False
 
     @staticmethod
     @abstractmethod
@@ -156,6 +180,19 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
                 f"{self._pretty_repr(value)}: Conversion to desired type failed."
             ) from exception
 
+    def _validate_or_raise(self, value: T) -> T:
+        """ Launches the custom validation callback on a value. Raises ValidationConfigurationError on failure. """
+        if self._cache_validated != value:
+            error_message = self._validation_callback(value)
+            if error_message:
+                raise ValidationConfigurationError(f"{self._pretty_repr(value)}: {error_message}")
+            self._cache_validated = copy(value)
+        return value
+
+    def _cast_and_validate(self, value: ConfigValue) -> T:
+        """ Cast and validate the value or raise an exception. """
+        return self._validate_or_raise(self._cast_or_raise(value))
+
     def _get_value(self) -> Optional[ConfigValue]:
         """Returns the raw value/fallback/override of this setting, else None."""
         value = (
@@ -166,6 +203,7 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         if value is None and self._fallback is not None:
             value = self._fallback() if callable(self._fallback) else self._fallback
 
+        self._last_value = copy(value)
         return value
 
     def _raise_if_missing(self) -> None:
@@ -173,13 +211,18 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         if not self.is_set:
             raise MandatoryConfigurationError(f'Mandatory config item "{self.key}" is missing.')
 
-    def _pretty_repr(self, value: Optional[ConfigValue]) -> str:
+    def _pretty_repr(self, value: Optional[Any]) -> str:
         value_str = "<sensitive>" if self._sensitive else "<not-set>" if value is None else value
         return f"{self.__class__.__name__}[{self.key}] = {value_str}"
 
     def __repr__(self) -> str:
         """ Returns a readable representation of the item for debugging. """
-        return self._pretty_repr(self._get_value())
+        # we are overly careful in not triggering mechanics (e.g.: _get_value()) from here.
+        # value is only shown if already computed.
+        value = next(
+            _ for _ in (self._cache_validated, self._last_value, "<not-evaluated>") if _ is not None
+        )
+        return self._pretty_repr(value)
 
     def __eq__(self, other: Any) -> bool:
         """ Indicates if the value is equal to another one. """

--- a/coveo-settings/tests_settings/test_settings.py
+++ b/coveo-settings/tests_settings/test_settings.py
@@ -34,7 +34,7 @@ def _clean_environment_variable(*environment_variable_name: str) -> None:
 
 @contextmanager
 def _clean_environment_context(*environment_variable_name: str) -> Generator[None, None, None]:
-    """ Context manager for the above function. """
+    """ Removes one or many environment variables before and after running the block. """
     try:
         _clean_environment_variable(*environment_variable_name)
         yield

--- a/coveo-settings/tests_settings/test_settings.py
+++ b/coveo-settings/tests_settings/test_settings.py
@@ -38,9 +38,8 @@ def _clean_environment_context(*environment_variable_name: str) -> Generator[Non
     try:
         _clean_environment_variable(*environment_variable_name)
         yield
-    except Exception:
+    finally:
         _clean_environment_variable(*environment_variable_name)
-        raise
 
 
 @UnitTest


### PR DESCRIPTION
This adds the possibility to add a validation callback that returns an error message if the value isn't correct. #46


note: this is a cumulative/sliced PR, if you prefer you can compare [the whole thing here](https://github.com/coveooss/coveo-python-oss/compare/feratures/bump).