### PR TITLE
Add ready made validation for coveo_settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .pytest_cache
 dist
 __pycache__
+.vscode/
+*.code-workspace

--- a/coveo-settings/README.md
+++ b/coveo-settings/README.md
@@ -71,6 +71,17 @@ Matching the key of the environment variable `project.database.ssl` is done very
 - dots and underscores are ignored completely (`foo_bar` and `f__ooba.r` are equal)
     - useful for some runners that don't support dots in environment variable keys
     
+## Use ready validation
+
+You can quickly validate that a string is in a specific list like this:
+
+```python
+from coveo_settings.settings import StringSetting
+from coveo_settings.validation import InSequence
+
+ENV = StringSetting("environment", fallback="dev", validation=InSequence("prod", "staging", "dev"))
+```
+
 
 ## Mocking
 

--- a/coveo-settings/coveo_settings/annotations.py
+++ b/coveo-settings/coveo_settings/annotations.py
@@ -1,0 +1,9 @@
+from typing import Union, Dict, TypeVar, Callable, Iterable
+
+
+ConfigValue = Union[str, int, float, bool, dict]
+ConfigDict = Dict[str, ConfigValue]
+
+T = TypeVar("T", str, int, float, bool, dict)
+ValidationCallback = Callable[[T], str]
+Validation = Union[ValidationCallback, Iterable[T]]

--- a/coveo-settings/coveo_settings/validation.py
+++ b/coveo-settings/coveo_settings/validation.py
@@ -1,0 +1,15 @@
+from typing import Optional, Sequence
+
+
+class InSequence:
+    def __init__(self, *args: str, condition: Optional[Sequence[str]] = None) -> None:
+        if condition is None:
+            self._condition = tuple(args)
+        else:
+            self._condition = tuple(condition)
+
+    def __call__(self, value: str) -> Optional[str]:
+        if value not in self._condition:
+            values = ", ".join(self._condition)
+            return f"Valid values are : {values}"
+        return None

--- a/coveo-settings/coveo_settings/validation.py
+++ b/coveo-settings/coveo_settings/validation.py
@@ -1,15 +1,14 @@
-from typing import Optional, Sequence
+from typing import Optional
+
+from .annotations import ConfigValue
 
 
 class InSequence:
-    def __init__(self, *args: str, condition: Optional[Sequence[str]] = None) -> None:
-        if condition is None:
-            self._condition = tuple(args)
-        else:
-            self._condition = tuple(condition)
+    def __init__(self, *args: ConfigValue) -> None:
+        self._condition = args
 
-    def __call__(self, value: str) -> Optional[str]:
+    def __call__(self, value: ConfigValue) -> Optional[str]:
         if value not in self._condition:
-            values = ", ".join(self._condition)
+            values = ", ".join(map(str, self._condition))
             return f"Valid values are : {values}"
         return None

--- a/coveo-settings/tests_settings/test_validation.py
+++ b/coveo-settings/tests_settings/test_validation.py
@@ -1,0 +1,38 @@
+import pytest
+
+from coveo_testing.markers import UnitTest
+from coveo_settings.settings import StringSetting, ValidationConfigurationError
+from coveo_settings.validation import InSequence
+
+
+@UnitTest
+def test_validation_in_sequence_positive() -> None:
+    """ Test InSequence validation """
+    validation = InSequence("first", "second")
+
+    # Positive test
+    test_setting_positive = StringSetting("ut", fallback="first", validation=validation)
+    assert test_setting_positive.value == "first"
+    assert str(test_setting_positive) == "first"
+    assert test_setting_positive.is_valid
+
+
+def test_validation_in_sequence_negative() -> None:
+    """ Test InSequence validation """
+    validation = InSequence("first", "second")
+
+    # Negative test
+    test_setting_negative = StringSetting("ut", fallback="third", validation=validation)
+    with pytest.raises(ValidationConfigurationError):
+        test_setting_negative.value
+    with pytest.raises(ValidationConfigurationError):
+        str(test_setting_negative)
+    assert not test_setting_negative.is_valid
+
+    # Test sensitive value
+    test_setting_sensitive = StringSetting(
+        "ut", sensitive=True, fallback="third", validation=validation
+    )
+    with pytest.raises(ValidationConfigurationError) as excinfo:
+        test_setting_sensitive.value
+    assert "third" not in str(excinfo.value)

--- a/coveo-settings/tests_settings/test_validation.py
+++ b/coveo-settings/tests_settings/test_validation.py
@@ -1,7 +1,13 @@
 import pytest
 
 from coveo_testing.markers import UnitTest
-from coveo_settings.settings import StringSetting, ValidationConfigurationError
+from coveo_settings.settings import (
+    StringSetting,
+    ValidationConfigurationError,
+    IntSetting,
+    FloatSetting,
+    ValidationCallbackError,
+)
 from coveo_settings.validation import InSequence
 
 
@@ -36,3 +42,21 @@ def test_validation_in_sequence_negative() -> None:
     with pytest.raises(ValidationConfigurationError) as excinfo:
         test_setting_sensitive.value
     assert "third" not in str(excinfo.value)
+
+
+def test_validation_magic() -> None:
+    assert isinstance(IntSetting("ut", validation=[1, 2, 3])._validation_callback, InSequence)
+
+
+def test_validation_magic_iterable_success() -> None:
+    assert FloatSetting("ut", fallback=1.0, validation=[1.0, 2, 3]).value == 1.0
+
+
+def test_validation_magic_iterable_failure() -> None:
+    with pytest.raises(ValidationConfigurationError):
+        _ = StringSetting("ut", fallback="hey", validation=["nope"]).value
+
+
+def test_validation_magic_iterable_failure_if_string() -> None:
+    with pytest.raises(ValidationCallbackError):
+        _ = StringSetting("ut", validation="no strings allowed")

--- a/coveo-settings/tests_settings/test_validation.py
+++ b/coveo-settings/tests_settings/test_validation.py
@@ -16,7 +16,6 @@ def test_validation_in_sequence_positive() -> None:
     """ Test InSequence validation """
     validation = InSequence("first", "second")
 
-    # Positive test
     test_setting_positive = StringSetting("ut", fallback="first", validation=validation)
     assert test_setting_positive.value == "first"
     assert str(test_setting_positive) == "first"
@@ -27,7 +26,6 @@ def test_validation_in_sequence_negative() -> None:
     """ Test InSequence validation """
     validation = InSequence("first", "second")
 
-    # Negative test
     test_setting_negative = StringSetting("ut", fallback="third", validation=validation)
     with pytest.raises(ValidationConfigurationError):
         test_setting_negative.value


### PR DESCRIPTION
I felt it was strange to have to write a method or a lambda for such a simple case of `value in ["first", "second"]`

You can now write this instead :
```python
from coveo_settings.settings import StringSetting
from coveo_settings.validation import InSequence

ENV = StringSetting("environment", fallback="dev", validation=InSequence("prod", "staging", "dev"))
```