### PR TITLE
coveo-settings // implement a PathLike

### DIFF
--- a/coveo-settings/README.md
+++ b/coveo-settings/README.md
@@ -17,6 +17,7 @@ When accessed, the values are automatically converted to the desired type:
 - `BoolSetting` is either True or False, but accepts "yes|no|true|false|1|0" as input (case-insensitive, of course)
 - `IntSetting` and `FloatSetting` are self-explanatory
 - `DictSetting` allows you to use JSON maps
+- `PathSetting` gives a Path instance, and also implements PathLike
 
 If the input cannot be converted to the value type, an `TypeConversionConfigurationError` exception is raised.
 

--- a/coveo-settings/coveo_settings/annotations.py
+++ b/coveo-settings/coveo_settings/annotations.py
@@ -1,9 +1,10 @@
+from pathlib import Path
 from typing import Union, Dict, TypeVar, Callable, Iterable
 
 
-ConfigValue = Union[str, int, float, bool, dict]
+ConfigValue = Union[str, int, float, bool, dict, Path]
 ConfigDict = Dict[str, ConfigValue]
 
-T = TypeVar("T", str, int, float, bool, dict)
+T = TypeVar("T", str, int, float, bool, dict, Path)
 ValidationCallback = Callable[[T], str]
 Validation = Union[ValidationCallback, Iterable[T]]

--- a/coveo-settings/coveo_settings/path_setting.py
+++ b/coveo-settings/coveo_settings/path_setting.py
@@ -32,5 +32,5 @@ class PathSetting(Setting[Path], PathLike):
 
     @staticmethod
     def _cast(value: ConfigValue) -> Path:
-        """Converts the value to a dictionary."""
+        """Converts the value to a Path."""
         return Path(value)  # type: ignore[arg-type]

--- a/coveo-settings/coveo_settings/path_setting.py
+++ b/coveo-settings/coveo_settings/path_setting.py
@@ -1,0 +1,36 @@
+from os import PathLike
+from pathlib import Path
+
+from coveo_settings.annotations import ConfigValue
+from coveo_settings.settings import Setting
+
+
+class PathSetting(Setting[Path], PathLike):
+    """
+    Setting that converts input to a Path instance; can also be used as PathLike.
+
+    e.g.:
+        setting = PathSetting(...)
+
+        # either a Path or None
+        optional_path = setting.value
+
+        # PathLike cannot be None; will raise if not set:
+        mandatory_path = Path(setting)
+
+        # mandatory-as-pathlike example; will raise if not set:
+        os.copy(setting, '/target/')
+
+        # str(PathSetting(...)) is exactly as doing str(Path(...)) and will raise if missing:
+        assert str(setting) == str(Path(setting))
+    """
+
+    def __fspath__(self) -> str:
+        """Implements PathLike: https://docs.python.org/3/library/os.html#os.PathLike."""
+        self._raise_if_missing()
+        return str(self.value)
+
+    @staticmethod
+    def _cast(value: ConfigValue) -> Path:
+        """Converts the value to a dictionary."""
+        return Path(value)  # type: ignore[arg-type]

--- a/coveo-settings/coveo_settings/settings.py
+++ b/coveo-settings/coveo_settings/settings.py
@@ -245,7 +245,7 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         equal = other == self.value
         if isinstance(equal, bool):
             return equal
-        return NotImplemented  # pragma: no cover
+        return NotImplemented
 
     def __bool__(self) -> bool:
         """ Indicates if the value is True (in python's terms). Missing values are False. """
@@ -259,15 +259,15 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
     def __int__(self) -> int:
         """ Returns the value, blindly converted to int. """
         self._raise_if_missing()
-        return int(self.value)  # type: ignore
+        return int(self.value)  # type: ignore[call-overload, no-any-return]
 
     def __float__(self) -> float:
         """ Return the value, blindly converted to float. """
         self._raise_if_missing()
-        return float(self.value)  # type: ignore
+        return float(self.value)  # type: ignore[arg-type]
 
 
-class AnySetting(Setting[Any]):  # pylint: disable=inherit-non-class
+class AnySetting(Setting[Any]):
     """ Setting class that performs no conversion. """
 
     @staticmethod
@@ -276,7 +276,7 @@ class AnySetting(Setting[Any]):  # pylint: disable=inherit-non-class
         return value  # type: ignore
 
 
-class BoolSetting(Setting[bool]):  # pylint: disable=inherit-non-class
+class BoolSetting(Setting[bool]):
     """
     Setting that handles bool values.
 
@@ -297,7 +297,7 @@ class BoolSetting(Setting[bool]):  # pylint: disable=inherit-non-class
         return value in BoolSetting.TRUE_VALUES
 
 
-class StringSetting(Setting[str]):  # pylint: disable=inherit-non-class
+class StringSetting(Setting[str]):
     """ Setting that handles string values. """
 
     @staticmethod
@@ -315,7 +315,7 @@ class StringSetting(Setting[str]):  # pylint: disable=inherit-non-class
         return value
 
 
-class IntSetting(Setting[int]):  # pylint: disable=inherit-non-class
+class IntSetting(Setting[int]):
     """ Setting that handles int values. """
 
     @staticmethod
@@ -329,7 +329,7 @@ class IntSetting(Setting[int]):  # pylint: disable=inherit-non-class
         return int(value)
 
 
-class FloatSetting(Setting[float]):  # pylint: disable=inherit-non-class
+class FloatSetting(Setting[float]):
     """ Setting that handles float values. """
 
     @staticmethod
@@ -341,7 +341,7 @@ class FloatSetting(Setting[float]):  # pylint: disable=inherit-non-class
         return float(value)
 
 
-class DictSetting(Setting[dict]):  # pylint: disable=inherit-non-class
+class DictSetting(Setting[dict]):
     """ Setting that handles a dictionary value. """
 
     def __getitem__(self, k: str) -> Any:

--- a/coveo-settings/tests_settings/test_path_setting.py
+++ b/coveo-settings/tests_settings/test_path_setting.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+import pytest
+
+from coveo_settings.path_setting import PathSetting
+from coveo_settings.annotations import ConfigValue
+from coveo_settings.settings import TypeConversionConfigurationError, MandatoryConfigurationError
+
+from coveo_testing.parametrize import parametrize
+
+
+def test_path_setting_basic() -> None:
+    assert PathSetting("test", fallback="/path/test").value == Path("/path/test")
+
+
+@parametrize("path", ("/path/test", "50"))
+def test_path_setting_pathlike(path: str) -> None:
+    """mypy sees it, but pycharm doesn't :shrug:"""
+    assert Path(PathSetting("test", fallback=path)) == Path(path)
+
+
+@parametrize("path", ({"test": "foo"}, False, 50))
+def test_path_setting_conversion_error(path: ConfigValue) -> None:
+    with pytest.raises(TypeConversionConfigurationError):
+        _ = PathSetting("test", fallback=path)
+
+
+def test_path_setting_not_set() -> None:
+    with pytest.raises(MandatoryConfigurationError):
+        _ = Path(PathSetting("test"))


### PR DESCRIPTION
This adds a `PathSetting` class that can be used to configure and use paths more naturally.