### PR TITLE
coveo-systools // Allow PathLike when it's trivial

### DIFF
--- a/coveo-systools/coveo_systools/filesystem.py
+++ b/coveo-systools/coveo_systools/filesystem.py
@@ -17,7 +17,7 @@ class CannotFindRepoRoot(Exception):
 
 
 @contextmanager
-def pushd(working_directory: Union[Path, str]) -> Iterator[None]:
+def pushd(working_directory: Union[os.PathLike, str]) -> Iterator[None]:
     """Change the current working directory for a block of code."""
     cwd = os.getcwd()
     try:
@@ -128,7 +128,9 @@ def _find_repo_root(path: Path) -> Path:
     ) from git_error
 
 
-def find_repo_root(path: Union[Path, str] = ".", *, default: Union[str, Path] = None) -> Path:
+def find_repo_root(
+    path: Union[os.PathLike, str] = ".", *, default: Union[str, os.PathLike] = None
+) -> Path:
     """Will find the root of a git repo based on the provided path.
 
     Will raise FileNotFoundError if it cannot be found.

--- a/coveo-systools/coveo_systools/subprocess.py
+++ b/coveo-systools/coveo_systools/subprocess.py
@@ -1,6 +1,7 @@
 """Adds much needed magic and features over the builtin subprocess machinery."""
 
 import logging
+from os import PathLike
 from pathlib import Path
 import subprocess
 from typing import Union, Any, Optional, cast, List, Dict, Tuple, Iterable
@@ -151,7 +152,7 @@ class _CallProtocol(Protocol):
 
 def check_run(
     *command: Any,
-    working_directory: Union[Path, str] = ".",
+    working_directory: Union[PathLike, str] = ".",
     capture_output: bool = False,
     verbose: bool = False,
     **kwargs: Any,
@@ -192,14 +193,20 @@ def check_run(
 
 
 def check_call(
-    *command: Any, working_directory: Union[Path, str] = ".", verbose: bool = False, **kwargs: Any
+    *command: Any,
+    working_directory: Union[PathLike, str] = ".",
+    verbose: bool = False,
+    **kwargs: Any,
 ) -> Optional[str]:
     """Proxy for subprocess.check_call"""
     return check_run(*command, working_directory=working_directory, verbose=verbose, **kwargs)
 
 
 def check_output(
-    *command: Any, working_directory: Union[Path, str] = ".", verbose: bool = False, **kwargs: Any
+    *command: Any,
+    working_directory: Union[PathLike, str] = ".",
+    verbose: bool = False,
+    **kwargs: Any,
 ) -> Optional[str]:
     """Proxy for subprocess.check_output"""
     return check_run(
@@ -232,6 +239,6 @@ def cast_command_line_argument_from_number(value: Union[int, float]) -> str:
     return str(value)
 
 
-@cast_command_line_argument_to_string.register(Path)
+@cast_command_line_argument_to_string.register(PathLike)  # PathLike is "runtime checkable"
 def cast_command_line_argument_from_path(value: Path) -> str:
     return str(value)

--- a/coveo-systools/coveo_systools/subprocess.py
+++ b/coveo-systools/coveo_systools/subprocess.py
@@ -240,5 +240,5 @@ def cast_command_line_argument_from_number(value: Union[int, float]) -> str:
 
 
 @cast_command_line_argument_to_string.register(PathLike)  # PathLike is "runtime checkable"
-def cast_command_line_argument_from_path(value: Path) -> str:
+def cast_command_line_argument_from_path(value: PathLike) -> str:
     return str(value)


### PR DESCRIPTION
When we accept a Path or str, we can generally accept a PathLike.