### PR TITLE
__contains__ and __iter__ magic

### DIFF
--- a/coveo-settings/coveo_settings/dict_setting.py
+++ b/coveo-settings/coveo_settings/dict_setting.py
@@ -18,7 +18,7 @@ class DictSetting(Setting[dict]):
 
     def __iter__(self) -> Iterator[str]:
         """Typical dict-keys iterator."""
-        return iter(self.value or {})
+        return super().__iter__()
 
     @staticmethod
     def _cast(value: ConfigValue) -> dict:

--- a/coveo-settings/coveo_settings/setting_abc.py
+++ b/coveo-settings/coveo_settings/setting_abc.py
@@ -23,6 +23,9 @@ from typing import (
     Generic,
     Collection,
     Callable,
+    Container,
+    Iterator,
+    Iterable,
 )
 
 from coveo_settings.annotations import ConfigValue, T, Validation, ValidationCallback
@@ -68,7 +71,7 @@ def _no_validation(_: ConfigValue) -> Optional[str]:
     return None
 
 
-class Setting(SupportsInt, SupportsFloat, Generic[T]):
+class Setting(SupportsInt, SupportsFloat, Generic[T], Container, Iterable):
     """
     Base class for magic type-checked settings.
 
@@ -243,3 +246,16 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         """Return the value, blindly converted to float."""
         self._raise_if_missing()
         return float(self.value)  # type: ignore[arg-type]
+
+    def __iter__(self) -> Iterator:
+        """Return the iterator for `value`. Will raise on unsupported types or missing values.
+        Note: T will not be used here, because in the case of e.g. Dictionaries you would get strings,
+        or a List of str would give back str...
+        """
+        self._raise_if_missing()
+        return iter(self.value)  # type: ignore[no-any-return,call-overload]
+
+    def __contains__(self, item: Any) -> bool:
+        """Tells if item is in `value`. Will raise on unsupported types or missing values."""
+        self._raise_if_missing()
+        return item in self.value  # type: ignore[operator]

--- a/coveo-settings/tests_settings/test_settings.py
+++ b/coveo-settings/tests_settings/test_settings.py
@@ -630,3 +630,57 @@ def test_setting_sensitive() -> None:
     setting._sensitive = False
     assert "sensitive" not in repr(setting)
     assert "foo" in repr(setting)
+
+
+@UnitTest
+def test_settings_contains() -> None:
+    assert "foo" in StringSetting("any", fallback="hey-foo-bar")
+    assert "foo" not in StringSetting("any", fallback="hey-boo-bar")
+
+
+@UnitTest
+def test_dict_settings_contains() -> None:
+    assert "foo" in DictSetting("any", fallback='{"foo": 0}')
+    assert "foo" not in DictSetting("any", fallback='{"boo": 0}')
+
+
+@UnitTest
+def test_settings_contains_not_supported() -> None:
+    with pytest.raises(TypeError):
+        assert "1" in IntSetting("any", fallback=123)
+
+
+@UnitTest
+def test_settings_contains_not_set() -> None:
+    with pytest.raises(MandatoryConfigurationError):
+        assert "1" in IntSetting("any")
+
+
+@UnitTest
+def test_settings_iterable() -> None:
+    loop = 0
+    for _ in StringSetting("any", fallback="hey"):
+        loop += 1
+    assert loop == 3
+
+
+@UnitTest
+def test_dict_settings_iterable() -> None:
+    data = {"test": 0, "foo": 0}
+    loop = 0
+    for key in DictSetting("any", fallback=data):
+        assert key in data
+        loop += 1
+    assert loop == 2
+
+
+@UnitTest
+def test_settings_iterable_not_supported() -> None:
+    with pytest.raises(TypeError):
+        iter(BoolSetting("any", fallback=False))
+
+
+@UnitTest
+def test_settings_iterable_not_set() -> None:
+    with pytest.raises(MandatoryConfigurationError):
+        iter(DictSetting("any"))


### PR DESCRIPTION
Also fixes iter in dict that didn't raise when missing. might be a breaking change for some, but we're early enough in 2.0 that I'm not too concerned.