### PR TITLE
Add a "get_if_set" 

### DIFF
--- a/coveo-settings/coveo_settings/setting_abc.py
+++ b/coveo-settings/coveo_settings/setting_abc.py
@@ -146,6 +146,10 @@ class Setting(SupportsInt, SupportsFloat, Generic[T]):
         except InvalidConfiguration:
             return False
 
+    def get_if_set(self, default: T) -> T:
+        """Return the value, or a default if not set."""
+        return self.value if self.is_set else default
+
     @staticmethod
     @abstractmethod
     def _cast(value: ConfigValue) -> T:

--- a/coveo-settings/tests_settings/test_settings.py
+++ b/coveo-settings/tests_settings/test_settings.py
@@ -630,3 +630,13 @@ def test_setting_sensitive() -> None:
     setting._sensitive = False
     assert "sensitive" not in repr(setting)
     assert "foo" in repr(setting)
+
+
+@UnitTest
+def test_setting_get_not_set() -> None:
+    assert StringSetting("any").get_if_set("default") == "default"
+
+
+@UnitTest
+def test_setting_get() -> None:
+    assert StringSetting("any", fallback="foo").get_if_set("default") == "foo"


### PR DESCRIPTION
Improves code readability in some areas.

e.g.:

```
    # before
    if "jenkins" in (MYSETTING.value or ""):
        ...

    #after
    if "jenkins" in MYSETTING.get_if_set(""):
        ...
```

Will play better when the expression is within a string interpolation as well.

I did not use `.get(...)`  because I did not want to introduce something weird vs the `DictSetting`, where you would expect get() to behave like on a dictionary.