### PR TITLE
New argument parsing behavior for code readability

### DIFF
--- a/coveo-systools/coveo_systools/subprocess.py
+++ b/coveo-systools/coveo_systools/subprocess.py
@@ -6,7 +6,6 @@ import shlex
 import subprocess
 from os import PathLike
 
-from coveo_systools.platforms import WINDOWS
 from typing import Union, Any, Optional, cast, List, Dict, Tuple, Iterable, Generator
 from typing_extensions import Protocol, Final, Literal
 
@@ -159,7 +158,7 @@ def _build_command(*command: Any, quoted: bool) -> Generator[str, None, None]:
         arg for arg in map(cast_command_line_argument_to_string, command) if arg and arg.strip()
     )
     yield from shlex.split(
-        " ".join(converted_command), posix=not WINDOWS
+        " ".join(converted_command), posix=False
     ) if quoted else converted_command
 
 

--- a/coveo-systools/coveo_systools/subprocess.py
+++ b/coveo-systools/coveo_systools/subprocess.py
@@ -220,7 +220,7 @@ def check_run(
     if verbose:
         print(f"input arguments: {command}")
 
-    converted_command = tuple(_build_command(*command, quoted=True))
+    converted_command = tuple(_build_command(*command, quoted=quoted))
     command_for_display = " ".join(converted_command) if quoted else shlex.join(converted_command)
 
     if verbose:

--- a/coveo-systools/tests_systools/test_build_command.py
+++ b/coveo-systools/tests_systools/test_build_command.py
@@ -1,0 +1,48 @@
+import shlex
+from typing import List
+
+from coveo_testing.parametrize import parametrize
+
+from coveo_systools.subprocess import _build_command
+
+
+TOKEN_WITH_SPACES = "some/file with spaces.txt"
+
+
+@parametrize("command", (["which", "git"], ["exec", "--option", "--target", TOKEN_WITH_SPACES]))
+def test_build_command(command: List[str]) -> None:
+    """By default (quoted=False) everything will be handled by Popen, later."""
+    assert list(_build_command(*command, quoted=False)) == command
+
+
+@parametrize(
+    ("command", "expected"),
+    (
+        (["which git"], ["which", "git"]),
+        (
+            ["exec --option", f"--target {shlex.quote(TOKEN_WITH_SPACES)}"],
+            ["exec", "--option", "--target", shlex.quote(TOKEN_WITH_SPACES)],
+        ),
+    ),
+)
+def test_build_command_quoted(command: List[str], expected: List[str]) -> None:
+    """With quoted=True, additional splitting occurs."""
+    assert list(_build_command(*command, quoted=True)) == expected
+
+
+def test_build_command_quoted_user_error() -> None:
+    """Demonstrates why you need to quote tokens if quoted=True."""
+    unquoted_command = f"exec --option {TOKEN_WITH_SPACES}"
+    assert (
+        " ".join(_build_command("exec", f"--option {TOKEN_WITH_SPACES}", quoted=True))
+        == unquoted_command
+    )
+
+
+def test_build_command_user_error() -> None:
+    """Demonstrates why you can't combine tokens if quoted=False."""
+    misplaced_quote = f"exec '--option {TOKEN_WITH_SPACES}'"
+    command = _build_command("exec", f"--option {TOKEN_WITH_SPACES}", quoted=False)
+
+    # shlex.join() gives us a (close enough for the test) Popen constructor behavior.
+    assert shlex.join(command) == misplaced_quote

--- a/coveo-systools/tests_systools/test_build_command.py
+++ b/coveo-systools/tests_systools/test_build_command.py
@@ -1,4 +1,6 @@
 import shlex
+from pathlib import Path
+
 from typing import List
 
 from coveo_testing.parametrize import parametrize
@@ -6,7 +8,7 @@ from coveo_testing.parametrize import parametrize
 from coveo_systools.subprocess import _build_command
 
 
-TOKEN_WITH_SPACES = "some/file with spaces.txt"
+TOKEN_WITH_SPACES = str(Path("folder") / "file with spaces.txt")
 
 
 @parametrize("command", (["which", "git"], ["exec", "--option", "--target", TOKEN_WITH_SPACES]))


### PR DESCRIPTION
new "Quoted" argument on check_* calls:

- When False, an argument is automatically quoted if it has a space (Popen's behavior):

```
        Good: 'exec', '--option', '--also', 'this value' -> exec --option --also "this value"
        Bad:  'exec', '--option', '--also this value' -> exec --option "--also this value" (quotes are misplaced)
```

- When True, the arguments will be split on spaces, unless you quoted them beforehand:
```
        Good: 'exec --option', '--also "this value"' -> exec --option --also "this value"
        Bad:  'exec', '--option', '--also', 'this value' -> exec --option --also this value (quotes are missing)
```

With `quoted=True` you can combine arguments together in single strings; this often improves readability.
However, you MUST quote the tokens that may contain a space. Example with black formatting:

without quoted:
```
        check_run(
            [
                "executable",
                "--verbose",
                "--target",
                filename,
                "--dry-run",
                "--with-onions"
            ]
        )
```
with quoted:

```
        import shlex
        check_run(
            [
                "executable --verbose",
                f"--target {shlex.quote(filename)}",
                "--dry-run --with-onions"
            ],
            quoted=True,
        )
```