### PR TITLE
Implement custom redirection into settings

### DIFF
--- a/coveo-settings/coveo_settings/__init__.py
+++ b/coveo-settings/coveo_settings/__init__.py
@@ -4,5 +4,5 @@ from coveo_settings.dict_setting import DictSetting
 from coveo_settings.float_setting import FloatSetting
 from coveo_settings.int_setting import IntSetting
 from coveo_settings.path_setting import PathSetting
-from coveo_settings.setting_abc import Setting
+from coveo_settings.setting_abc import Setting, settings_adapter, ConfigValue
 from coveo_settings.string_setting import StringSetting

--- a/coveo-settings/coveo_settings/exceptions.py
+++ b/coveo-settings/coveo_settings/exceptions.py
@@ -1,3 +1,15 @@
+class InvalidScheme(RuntimeError):
+    """Thrown when a scheme is not valid."""
+
+
+class DuplicatedScheme(InvalidScheme):
+    """Thrown when a scheme is duplicated."""
+
+
+class TooManyRedirects(RuntimeError):
+    """A setting tried to redirect to custom adapters too many times."""
+
+
 class InvalidConfiguration(Exception):
     """Thrown when a setting item is badly configured."""
 

--- a/coveo-settings/tests_settings/test_settings_adapter.py
+++ b/coveo-settings/tests_settings/test_settings_adapter.py
@@ -3,7 +3,11 @@ import os
 from typing import Optional, Final
 
 import pytest
-from coveo_settings.exceptions import DuplicatedScheme, TooManyRedirects, TypeConversionConfigurationError
+from coveo_settings.exceptions import (
+    DuplicatedScheme,
+    TooManyRedirects,
+    TypeConversionConfigurationError,
+)
 from coveo_testing.markers import UnitTest
 from coveo_testing.parametrize import parametrize
 
@@ -96,11 +100,11 @@ def test_adapter_may_cast_object() -> None:
 
     @settings_adapter("return-dict::")
     def return_dict(value: str) -> Optional[ConfigValue]:
-        return json.loads(value)
+        return json.loads(value)  # type: ignore[no-any-return]
 
     value = 'return-dict::{"success": true}'
-    assert DictSetting('...', fallback=value).value['success'] is True
+    assert DictSetting("...", fallback=value).value["success"] is True
 
     with pytest.raises(TypeConversionConfigurationError):
         # providing a dictionary to a BoolSetting is never a good idea!
-        _ = BoolSetting('...', fallback=value).value
+        _ = BoolSetting("...", fallback=value).value

--- a/coveo-settings/tests_settings/test_settings_adapter.py
+++ b/coveo-settings/tests_settings/test_settings_adapter.py
@@ -34,14 +34,14 @@ def return_value_adapter(value: str) -> Optional[ConfigValue]:
 @UnitTest
 @parametrize_scheme
 def test_setting_adapter(scheme: str) -> None:
-    assert StringSetting("...", fallback=f"{scheme}foo").value == "foo"
+    assert StringSetting("ut", fallback=f"{scheme}foo").value == "foo"
 
 
 @UnitTest
 @parametrize_scheme
 def test_setting_adapter_no_match(scheme: str) -> None:
     expected = f"{scheme[:-1]}foo"
-    assert StringSetting("...", fallback=expected).value == expected
+    assert StringSetting("ut", fallback=expected).value == expected
 
 
 @UnitTest
@@ -57,7 +57,7 @@ def test_duplicate_scheme(scheme: str) -> None:
 @UnitTest
 def test_scheme_case_insensitive() -> None:
     assert TEST_RETURN_VALUE.islower()
-    assert StringSetting("...", fallback=f"{TEST_RETURN_VALUE.upper()}foo").value == "foo"
+    assert StringSetting("ut", fallback=f"{TEST_RETURN_VALUE.upper()}foo").value == "foo"
 
 
 @UnitTest
@@ -87,7 +87,7 @@ def test_redirect_not_called_on_is_set() -> None:
         called = True
         return value
 
-    setting = BoolSetting("...", fallback="lazy-evaluated::yes")
+    setting = BoolSetting("ut", fallback="lazy-evaluated::yes")
     assert setting.is_set
     assert not called
     assert setting.value is True
@@ -103,8 +103,8 @@ def test_adapter_may_cast_object() -> None:
         return json.loads(value)  # type: ignore[no-any-return]
 
     value = 'return-dict::{"success": true}'
-    assert DictSetting("...", fallback=value).value["success"] is True
+    assert DictSetting("ut", fallback=value).value["success"] is True
 
     with pytest.raises(TypeConversionConfigurationError):
         # providing a dictionary to a BoolSetting is never a good idea!
-        _ = BoolSetting("...", fallback=value).value
+        _ = BoolSetting("ut", fallback=value).value

--- a/coveo-settings/tests_settings/test_settings_adapter.py
+++ b/coveo-settings/tests_settings/test_settings_adapter.py
@@ -1,0 +1,106 @@
+import json
+import os
+from typing import Optional, Final
+
+import pytest
+from coveo_settings.exceptions import DuplicatedScheme, TooManyRedirects, TypeConversionConfigurationError
+from coveo_testing.markers import UnitTest
+from coveo_testing.parametrize import parametrize
+
+from coveo_settings import StringSetting, BoolSetting, DictSetting
+from coveo_settings.annotations import ConfigValue
+from coveo_settings.setting_abc import settings_adapter
+
+
+TEST_RETURN_VALUE: Final[str] = "return-value::"
+TEST_REGEX_ESCAPE: Final[str] = r"[\w].*"
+TEST_GARBAGE: Final[str] = r"<>{}!?+-_.|^&\/()"
+
+
+parametrize_scheme = parametrize("scheme", (TEST_RETURN_VALUE, TEST_REGEX_ESCAPE, TEST_GARBAGE))
+
+
+@settings_adapter(TEST_REGEX_ESCAPE)
+@settings_adapter(TEST_RETURN_VALUE)
+@settings_adapter(TEST_GARBAGE)
+def return_value_adapter(value: str) -> Optional[ConfigValue]:
+    return value
+
+
+@UnitTest
+@parametrize_scheme
+def test_setting_adapter(scheme: str) -> None:
+    assert StringSetting("...", fallback=f"{scheme}foo").value == "foo"
+
+
+@UnitTest
+@parametrize_scheme
+def test_setting_adapter_no_match(scheme: str) -> None:
+    expected = f"{scheme[:-1]}foo"
+    assert StringSetting("...", fallback=expected).value == expected
+
+
+@UnitTest
+@parametrize_scheme
+def test_duplicate_scheme(scheme: str) -> None:
+    with pytest.raises(DuplicatedScheme):
+
+        @settings_adapter(scheme)
+        def dummy(_: str) -> ConfigValue:
+            ...
+
+
+@UnitTest
+def test_scheme_case_insensitive() -> None:
+    assert TEST_RETURN_VALUE.islower()
+    assert StringSetting("...", fallback=f"{TEST_RETURN_VALUE.upper()}foo").value == "foo"
+
+
+@UnitTest
+def test_builtin_redirection() -> None:
+    os.environ["test-expected"] = TEST_RETURN_VALUE + "foo"
+    os.environ["test-migrated"] = "env->test-expected"
+    os.environ["test-redirect"] = "env->test-migrated"
+    assert StringSetting("test-redirect").value == "foo"
+
+
+@UnitTest
+def test_too_many_redirects() -> None:
+    os.environ["test-migrated"] = "env->test-redirect"
+    os.environ["test-redirect"] = "env->test-migrated"
+
+    with pytest.raises(TooManyRedirects):
+        _ = StringSetting("test-redirect").value
+
+
+@UnitTest
+def test_redirect_not_called_on_is_set() -> None:
+    called = False
+
+    @settings_adapter("lazy-evaluated::")
+    def adapter(value: str) -> Optional[str]:
+        nonlocal called
+        called = True
+        return value
+
+    setting = BoolSetting("...", fallback="lazy-evaluated::yes")
+    assert setting.is_set
+    assert not called
+    assert setting.value is True
+    assert called
+
+
+@UnitTest
+def test_adapter_may_cast_object() -> None:
+    """Demonstrates that the handler may cast the value in advance."""
+
+    @settings_adapter("return-dict::")
+    def return_dict(value: str) -> Optional[ConfigValue]:
+        return json.loads(value)
+
+    value = 'return-dict::{"success": true}'
+    assert DictSetting('...', fallback=value).value['success'] is True
+
+    with pytest.raises(TypeConversionConfigurationError):
+        # providing a dictionary to a BoolSetting is never a good idea!
+        _ = BoolSetting('...', fallback=value).value


### PR DESCRIPTION
The user is no longer limited to environment variables. It is now possible to write custom callbacks to defer obtaining the value of a setting.

A more realistic example would be to support values such as `ssm://env/app/param` or `secretsmanager://arn` and the likes.

## Redirection

You can register custom redirection schemes in order to support any data source.

Much like `https://` is a clear scheme, you may register callback functions to trigger when the value of a setting
starts with the scheme(s) you define. For instance, let's support a custom API and a file storage: 

```python
from coveo_settings import settings_adapter, StringSetting, ConfigValue

@settings_adapter("internal-api::")
def internal_api_adapter(key: str) -> ConfigValue:
    # the scheme was automatically removed for convenience; only the resource remains  
    assert "internal-api::" not in key
    return "internal api"  # implement logic to obtain value from internal api
    
@settings_adapter("file::")
def file_adapter(key: str) -> ConfigValue:
    return "file adapter"  # implement logic to parse the key and retrieve the setting value 

assert StringSetting('...', fallback="internal-api::settings/user-name").value == "internal api"
assert StringSetting('...', fallback="file::settings.yaml/user-name").value == "file adapter"

# even though we used `fallback` above, the redirection is driven by the user:
import os

REDIRECT_ME = StringSetting('test')

os.environ['test'] = "file::user.json::name"
assert REDIRECT_ME.value == "file adapter"
os.environ['test'] = "internal-api::url"
assert REDIRECT_ME.value == "internal api"
```

Keep in mind that there's no restriction on the prefix scheme; it's your responsibility to pick something unique 
that can be set as the value of an environment variable.


### Redirection is recursive

The value of a redirection may be another redirection and may juggle between adapters. 
A limit of 50 redirections is supported:

```python
import os

from coveo_settings import StringSetting


os.environ["expected"] = "final value"
os.environ["redirected"] = "env->expected"
os.environ["my-setting"] = "env->redirected"

assert StringSetting("my-setting").value == "final value"
```

### Builtin environment redirection

The builtin redirection scheme `env->` can be used to redirect to a different environment variable.
The example below demonstrates the deprecation/migration of `my-setting` into `new-setting`: 

```python
import os

from coveo_settings import StringSetting


os.environ["new-setting"] = "correct-value"
os.environ["my-setting"] = "env->new-setting"

assert StringSetting("my-setting").value == "correct-value"
```