### PR TITLE
feature // (PART OF #78) flex v2

### DIFF
--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -11,19 +11,22 @@ Introspect classes and callables at runtime.
 Can convert string annotations into their actual type reference.
 
 
-## casing / flexcase
+## flex
 
-Flexcase takes a "dirty" input and maps it to a python construct.
+Note: Flex only works with keyword arguments.
+
+Flex takes a "dirty" input and maps it to a python construct.
 
 The principal use case is to allow seamless translation between snake_case and camelCase and generate PEP8-compliant code over APIs that support a different casing scheme.
 
-- It introspects a function to obtain the expected argument names
+- It introspects a function/class to obtain the expected argument names
 - It inspects the provided input to find matching candidates
 - It calls the function with the cleaned arguments
+- It can recurse into nested custom types based on annotations
 
 It can also be used to allow for a certain degree of personalization in typically strict contexts such as configuration files and APIs. 
 
-Take for example the toml below, where all 3 items are equivalent:
+Take for example the toml below, where all 3 items can be made equivalent:
 
 ```toml
 [tool.some-plugin]
@@ -39,6 +42,38 @@ Or maybe in a CLI app, to allow both underscores and dashes:
 poetry install --no-dev
 poetry install --no_dev
 ```
+
+### unflex
+
+With unflex, you can remap a dictionary to fit the keyword arguments given by a function call:
+
+```python
+from coveo_functools.flex import unflex
+
+def fn(arg1: str, arg2: str) -> None:
+    ...
+
+assert unflex(fn, {"ARG1": ..., "ArG_2": ...}) == {"arg1": ..., "arg2": ...}
+```
+
+### flexcase
+
+`flexcase` is a decorator that allows a function to apply the `unflex` logic automatically:
+
+```python
+from coveo_functools.flex import flexcase
+
+@flexcase
+def fn(arg1: str, arg2: str) -> str:
+    return f"{arg1} {arg2}"
+
+
+assert fn(ARG1="hello", _arg2="world") == "hello world"
+```
+
+### FlexFactory
+
+This class decorator allows you to  
 
 
 ## dispatch

--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -1,0 +1,10 @@
+class CoveoFunctoolsException(Exception):
+    """Base class for coveo-functools exceptions."""
+
+
+class FlexException(CoveoFunctoolsException):
+    """Base class for exceptions raised by the flex module."""
+
+
+class InvalidUnion(FlexException):
+    """An invalid union was provided."""

--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -6,9 +6,5 @@ class FlexException(CoveoFunctoolsException):
     """Base class for exceptions raised by the flex module."""
 
 
-class InvalidUnion(FlexException):
+class AmbiguousAnnotation(FlexException):
     """An invalid union was provided."""
-
-
-class PositionalArgumentsNotAllowed(CoveoFunctoolsException, RuntimeError):
-    """When positional args are detected in the calls."""

--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -8,3 +8,7 @@ class FlexException(CoveoFunctoolsException):
 
 class InvalidUnion(FlexException):
     """An invalid union was provided."""
+
+
+class PositionalArgumentsNotAllowed(CoveoFunctoolsException, RuntimeError):
+    """When positional args are detected in the calls."""

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -28,6 +28,9 @@ class FlexFactory(Generic[T]):
 
         # scan the annotations for custom types and convert them
         for arg_name, arg_type in find_annotations(self.klass).items():
+            if arg_name not in mapped_kwargs:
+                continue  # this may be ok if the target class has a default value, will break if not
+
             if arg_type in JSON_TYPES:
                 converted_kwargs[arg_name] = mapped_kwargs[arg_name]
                 continue  # assume that builtin types are already converted

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -68,9 +68,15 @@ def _convert(
                         # not sure if this is even possible... Union[None, None] ?
                         arg_value = mapped_kwargs[arg_name]
                     elif len(allowed_types) > 1:
+                        # todo: we should allow things like Union[T, List[T]] (one or many)
                         raise AmbiguousAnnotation(meta_type)
                     else:
                         arg_value = flex(allowed_types[0])(**mapped_kwargs[arg_name])
+
+            # elif meta_type in (List, Set, Iterable, Collection, Sequence):
+            #     ...  # handle lists/etc
+            # elif meta_type in (Dict, Mapping, MutableMapping):
+            #     ...  # handle mappings
 
             elif meta_type:
                 raise FlexException(f"Unsupported type: {meta_type}")

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import Type, TypeVar, Generic, Optional, Any
+from typing import Type, TypeVar, Generic, Optional, Any, get_args, get_origin, Union, Dict
 
 from coveo_functools.annotations import find_annotations
 from coveo_functools.casing import unflex
+from coveo_functools.exceptions import InvalidUnion
 
 JSON_TYPES = (str, bool, int, float, type(None))
+META_TYPES = (Union, Optional)
 
 
 T = TypeVar("T")
@@ -21,17 +23,30 @@ class FlexFactory(Generic[T]):
 
     def __call__(self, **dirty_kwargs: Any) -> T:
         # convert the keys casings to match the target class
-        converted_arguments = unflex(self.klass.__init__, dirty_kwargs, strip_extra=self.strip_extras)
+        mapped_kwargs = unflex(self.klass.__init__, dirty_kwargs, strip_extra=self.strip_extras)
+        converted_kwargs: Dict[str, Any] = {}
 
         # scan the annotations for custom types and convert them
         for arg_name, arg_type in find_annotations(self.klass).items():
-            if arg_type not in JSON_TYPES:
-                # convert the argument to the target class
-                factory = FlexFactory(arg_type, strip_extras=self.strip_extras, keep_raw=self.keep_raw)
-                converted_arguments[arg_name] = factory(**converted_arguments[arg_name])
+            if arg_type in JSON_TYPES:
+                converted_kwargs[arg_name] = mapped_kwargs[arg_name]
+                continue  # assume that builtin types are already converted
+
+            meta_type = get_origin(arg_type)
+            if meta_type in (Optional, Union):
+                allowed_types = get_args(arg_type)
+                if not all(_type in JSON_TYPES for _type in allowed_types):
+                    raise InvalidUnion(meta_type)
+
+                converted_kwargs[arg_name] = mapped_kwargs[arg_name]
+                continue  # assume that builtin types are already converted
+
+            # convert the argument to the target class
+            factory = FlexFactory(arg_type, strip_extras=self.strip_extras, keep_raw=self.keep_raw)
+            converted_kwargs[arg_name] = factory(**mapped_kwargs[arg_name])
 
         # with everything converted, create an instance of the class
-        instance = self.klass(**converted_arguments)
+        instance = self.klass(**converted_kwargs)
 
         # keep raw data?
         if self.keep_raw and hasattr(instance, "__dict__"):

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Type, TypeVar, Generic, Optional, Any
+
+from coveo_functools.annotations import find_annotations
+from coveo_functools.casing import unflex
+
+JSON_TYPES = (str, bool, int, float, type(None))
+
+
+T = TypeVar("T")
+U = TypeVar("U")
+
+
+class FlexFactory(Generic[T]):
+
+    def __init__(self, klass: Type[T], strip_extras: bool = True, keep_raw: Optional[str] = None) -> None:
+        self.klass = klass
+        self.strip_extras = strip_extras
+        self.keep_raw = keep_raw
+
+    def __call__(self, **dirty_kwargs: Any) -> T:
+        # convert the keys casings to match the target class
+        converted_arguments = unflex(self.klass.__init__, dirty_kwargs, strip_extra=self.strip_extras)
+
+        # scan the annotations for custom types and convert them
+        for arg_name, arg_type in find_annotations(self.klass).items():
+            if arg_type not in JSON_TYPES:
+                # convert the argument to the target class
+                factory = FlexFactory(arg_type, strip_extras=self.strip_extras, keep_raw=self.keep_raw)
+                converted_arguments[arg_name] = factory(**converted_arguments[arg_name])
+
+        # with everything converted, create an instance of the class
+        instance = self.klass(**converted_arguments)
+
+        # keep raw data?
+        if self.keep_raw and hasattr(instance, "__dict__"):
+            # can't do that if slots-based
+            instance.__dict__[self.keep_raw] = dirty_kwargs
+
+        return instance

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -15,8 +15,9 @@ U = TypeVar("U")
 
 
 class FlexFactory(Generic[T]):
-
-    def __init__(self, klass: Type[T], strip_extras: bool = True, keep_raw: Optional[str] = None) -> None:
+    def __init__(
+        self, klass: Type[T], strip_extras: bool = True, keep_raw: Optional[str] = None
+    ) -> None:
         self.klass = klass
         self.strip_extras = strip_extras
         self.keep_raw = keep_raw
@@ -27,7 +28,7 @@ class FlexFactory(Generic[T]):
         converted_kwargs: Dict[str, Any] = {}
 
         # scan the annotations for custom types and convert them
-        for arg_name, arg_type in find_annotations(self.klass).items():
+        for arg_name, arg_type in find_annotations(self.klass.__init__).items():
             if arg_name not in mapped_kwargs:
                 continue  # this may be ok if the target class has a default value, will break if not
 
@@ -49,7 +50,7 @@ class FlexFactory(Generic[T]):
             converted_kwargs[arg_name] = factory(**mapped_kwargs[arg_name])
 
         # with everything converted, create an instance of the class
-        instance = self.klass(**converted_kwargs)
+        instance = self.klass(**converted_kwargs)  # type: ignore[call-arg]
 
         # keep raw data?
         if self.keep_raw and hasattr(instance, "__dict__"):

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -1,11 +1,22 @@
 from __future__ import annotations
 
 import inspect
-from typing import Type, TypeVar, Generic, Optional, Any, get_args, get_origin, Union, Dict
+from typing import (
+    Type,
+    TypeVar,
+    Generic,
+    Optional,
+    Any,
+    get_args,
+    get_origin,
+    Union,
+    Dict,
+    Callable,
+)
 
 from coveo_functools.annotations import find_annotations
 from coveo_functools.casing import unflex, flexcase
-from coveo_functools.exceptions import InvalidUnion, PositionalArgumentsNotAllowed, FlexException
+from coveo_functools.exceptions import InvalidUnion, PositionalArgumentsNotAllowed
 
 _ = unflex, flexcase  # mark them as used (forward compatibility vs docs)
 
@@ -20,7 +31,7 @@ T = TypeVar("T")
 class FlexFactory(Generic[T]):
     def __init__(
         self,
-        __wrapped: Optional[Type[T]] = None,
+        __wrapped: Optional[Union[Type[T], Callable[..., T]]] = None,
         *,
         strip_extras: bool = True,
         keep_raw: Optional[str] = None
@@ -47,11 +58,10 @@ class FlexFactory(Generic[T]):
             return self  # type: ignore[return-value]
 
         if inspect.isclass(self.__wrapped):
-            fn = self.__wrapped.__init__
+            fn: Callable[..., T] = self.__wrapped.__init__  # type: ignore[misc]
         else:
-            raise FlexException(':soon:')
-            # assert callable(self.__wrapped)
-            # fn = self.__wrapped
+            assert callable(self.__wrapped)
+            fn = self.__wrapped
 
         # convert the keys casings to match the target class
         mapped_kwargs = unflex(fn, dirty_kwargs, strip_extra=self.strip_extras)

--- a/coveo-functools/poetry.lock
+++ b/coveo-functools/poetry.lock
@@ -104,7 +104,7 @@ python-versions = "*"
 
 [[package]]
 name = "mypy"
-version = "0.812"
+version = "0.910"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -112,11 +112,12 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 mypy-extensions = ">=0.4.3,<0.5.0"
-typed-ast = ">=1.4.0,<1.5.0"
+toml = "*"
 typing-extensions = ">=3.7.4"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
+python2 = ["typed-ast (>=1.4.0,<1.5.0)"]
 
 [[package]]
 name = "mypy-extensions"
@@ -195,7 +196,7 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 name = "regex"
-version = "2021.4.4"
+version = "2021.7.1"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -210,14 +211,6 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
-name = "typed-ast"
-version = "1.4.3"
-description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
@@ -228,7 +221,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "284a7417b1e3d3403e7dc5fcef0cf086c9f44b9b1dcc67253be1f47dab8680b9"
+content-hash = "32c7e4035863c3ee30fd5dcd8238a5a325badefd7d1b21d5340ba3a8cc4eda52"
 
 [metadata.files]
 appdirs = [
@@ -265,28 +258,29 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 mypy = [
-    {file = "mypy-0.812-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a26f8ec704e5a7423c8824d425086705e381b4f1dfdef6e3a1edab7ba174ec49"},
-    {file = "mypy-0.812-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28fb5479c494b1bab244620685e2eb3c3f988d71fd5d64cc753195e8ed53df7c"},
-    {file = "mypy-0.812-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:9743c91088d396c1a5a3c9978354b61b0382b4e3c440ce83cf77994a43e8c521"},
-    {file = "mypy-0.812-cp35-cp35m-win_amd64.whl", hash = "sha256:d7da2e1d5f558c37d6e8c1246f1aec1e7349e4913d8fb3cb289a35de573fe2eb"},
-    {file = "mypy-0.812-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:4eec37370483331d13514c3f55f446fc5248d6373e7029a29ecb7b7494851e7a"},
-    {file = "mypy-0.812-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d65cc1df038ef55a99e617431f0553cd77763869eebdf9042403e16089fe746c"},
-    {file = "mypy-0.812-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:61a3d5b97955422964be6b3baf05ff2ce7f26f52c85dd88db11d5e03e146a3a6"},
-    {file = "mypy-0.812-cp36-cp36m-win_amd64.whl", hash = "sha256:25adde9b862f8f9aac9d2d11971f226bd4c8fbaa89fb76bdadb267ef22d10064"},
-    {file = "mypy-0.812-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:552a815579aa1e995f39fd05dde6cd378e191b063f031f2acfe73ce9fb7f9e56"},
-    {file = "mypy-0.812-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:499c798053cdebcaa916eef8cd733e5584b5909f789de856b482cd7d069bdad8"},
-    {file = "mypy-0.812-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:5873888fff1c7cf5b71efbe80e0e73153fe9212fafdf8e44adfe4c20ec9f82d7"},
-    {file = "mypy-0.812-cp37-cp37m-win_amd64.whl", hash = "sha256:9f94aac67a2045ec719ffe6111df543bac7874cee01f41928f6969756e030564"},
-    {file = "mypy-0.812-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d23e0ea196702d918b60c8288561e722bf437d82cb7ef2edcd98cfa38905d506"},
-    {file = "mypy-0.812-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:674e822aa665b9fd75130c6c5f5ed9564a38c6cea6a6432ce47eafb68ee578c5"},
-    {file = "mypy-0.812-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:abf7e0c3cf117c44d9285cc6128856106183938c68fd4944763003decdcfeb66"},
-    {file = "mypy-0.812-cp38-cp38-win_amd64.whl", hash = "sha256:0d0a87c0e7e3a9becdfbe936c981d32e5ee0ccda3e0f07e1ef2c3d1a817cf73e"},
-    {file = "mypy-0.812-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:7ce3175801d0ae5fdfa79b4f0cfed08807af4d075b402b7e294e6aa72af9aa2a"},
-    {file = "mypy-0.812-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b09669bcda124e83708f34a94606e01b614fa71931d356c1f1a5297ba11f110a"},
-    {file = "mypy-0.812-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:33f159443db0829d16f0a8d83d94df3109bb6dd801975fe86bacb9bf71628e97"},
-    {file = "mypy-0.812-cp39-cp39-win_amd64.whl", hash = "sha256:3f2aca7f68580dc2508289c729bd49ee929a436208d2b2b6aab15745a70a57df"},
-    {file = "mypy-0.812-py3-none-any.whl", hash = "sha256:2f9b3407c58347a452fc0736861593e105139b905cca7d097e413453a1d650b4"},
-    {file = "mypy-0.812.tar.gz", hash = "sha256:cd07039aa5df222037005b08fbbfd69b3ab0b0bd7a07d7906de75ae52c4e3119"},
+    {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
+    {file = "mypy-0.910-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:088cd9c7904b4ad80bec811053272986611b84221835e079be5bcad029e79dd9"},
+    {file = "mypy-0.910-cp35-cp35m-win_amd64.whl", hash = "sha256:adaeee09bfde366d2c13fe6093a7df5df83c9a2ba98638c7d76b010694db760e"},
+    {file = "mypy-0.910-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:ecd2c3fe726758037234c93df7e98deb257fd15c24c9180dacf1ef829da5f921"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:d9dd839eb0dc1bbe866a288ba3c1afc33a202015d2ad83b31e875b5905a079b6"},
+    {file = "mypy-0.910-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:3e382b29f8e0ccf19a2df2b29a167591245df90c0b5a2542249873b5c1d78212"},
+    {file = "mypy-0.910-cp36-cp36m-win_amd64.whl", hash = "sha256:53fd2eb27a8ee2892614370896956af2ff61254c275aaee4c230ae771cadd885"},
+    {file = "mypy-0.910-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b6fb13123aeef4a3abbcfd7e71773ff3ff1526a7d3dc538f3929a49b42be03f0"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4dab234478e3bd3ce83bac4193b2ecd9cf94e720ddd95ce69840273bf44f6de"},
+    {file = "mypy-0.910-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:7df1ead20c81371ccd6091fa3e2878559b5c4d4caadaf1a484cf88d93ca06703"},
+    {file = "mypy-0.910-cp37-cp37m-win_amd64.whl", hash = "sha256:0aadfb2d3935988ec3815952e44058a3100499f5be5b28c34ac9d79f002a4a9a"},
+    {file = "mypy-0.910-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ec4e0cd079db280b6bdabdc807047ff3e199f334050db5cbb91ba3e959a67504"},
+    {file = "mypy-0.910-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:119bed3832d961f3a880787bf621634ba042cb8dc850a7429f643508eeac97b9"},
+    {file = "mypy-0.910-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:866c41f28cee548475f146aa4d39a51cf3b6a84246969f3759cb3e9c742fc072"},
+    {file = "mypy-0.910-cp38-cp38-win_amd64.whl", hash = "sha256:ceb6e0a6e27fb364fb3853389607cf7eb3a126ad335790fa1e14ed02fba50811"},
+    {file = "mypy-0.910-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1a85e280d4d217150ce8cb1a6dddffd14e753a4e0c3cf90baabb32cefa41b59e"},
+    {file = "mypy-0.910-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:42c266ced41b65ed40a282c575705325fa7991af370036d3f134518336636f5b"},
+    {file = "mypy-0.910-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3c4b8ca36877fc75339253721f69603a9c7fdb5d4d5a95a1a1b899d8b86a4de2"},
+    {file = "mypy-0.910-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c0df2d30ed496a08de5daed2a9ea807d07c21ae0ab23acf541ab88c24b26ab97"},
+    {file = "mypy-0.910-cp39-cp39-win_amd64.whl", hash = "sha256:c6c2602dffb74867498f86e6129fd52a2770c48b7cd3ece77ada4fa38f94eba8"},
+    {file = "mypy-0.910-py3-none-any.whl", hash = "sha256:ef565033fa5a958e62796867b1df10c40263ea9ded87164d67572834e57a174d"},
+    {file = "mypy-0.910.tar.gz", hash = "sha256:704098302473cb31a218f1775a873b376b30b4c18229421e9e9dc8916fd16150"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -317,83 +311,47 @@ pytest = [
     {file = "pytest-6.2.4.tar.gz", hash = "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b"},
 ]
 regex = [
-    {file = "regex-2021.4.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:619d71c59a78b84d7f18891fe914446d07edd48dc8328c8e149cbe0929b4e000"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:47bf5bf60cf04d72bf6055ae5927a0bd9016096bf3d742fa50d9bf9f45aa0711"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:281d2fd05555079448537fe108d79eb031b403dac622621c78944c235f3fcf11"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bd28bc2e3a772acbb07787c6308e00d9626ff89e3bfcdebe87fa5afbfdedf968"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c2a1af393fcc09e898beba5dd59196edaa3116191cc7257f9224beaed3e1aa0"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c38c71df845e2aabb7fb0b920d11a1b5ac8526005e533a8920aea97efb8ec6a4"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:96fcd1888ab4d03adfc9303a7b3c0bd78c5412b2bfbe76db5b56d9eae004907a"},
-    {file = "regex-2021.4.4-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:ade17eb5d643b7fead300a1641e9f45401c98eee23763e9ed66a43f92f20b4a7"},
-    {file = "regex-2021.4.4-cp36-cp36m-win32.whl", hash = "sha256:e8e5b509d5c2ff12f8418006d5a90e9436766133b564db0abaec92fd27fcee29"},
-    {file = "regex-2021.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:11d773d75fa650cd36f68d7ca936e3c7afaae41b863b8c387a22aaa78d3c5c79"},
-    {file = "regex-2021.4.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d3029c340cfbb3ac0a71798100ccc13b97dddf373a4ae56b6a72cf70dfd53bc8"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:18c071c3eb09c30a264879f0d310d37fe5d3a3111662438889ae2eb6fc570c31"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4c557a7b470908b1712fe27fb1ef20772b78079808c87d20a90d051660b1d69a"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:01afaf2ec48e196ba91b37451aa353cb7eda77efe518e481707e0515025f0cd5"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:3a9cd17e6e5c7eb328517969e0cb0c3d31fd329298dd0c04af99ebf42e904f82"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:90f11ff637fe8798933fb29f5ae1148c978cccb0452005bf4c69e13db951e765"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:919859aa909429fb5aa9cf8807f6045592c85ef56fdd30a9a3747e513db2536e"},
-    {file = "regex-2021.4.4-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:339456e7d8c06dd36a22e451d58ef72cef293112b559010db3d054d5560ef439"},
-    {file = "regex-2021.4.4-cp37-cp37m-win32.whl", hash = "sha256:67bdb9702427ceddc6ef3dc382455e90f785af4c13d495f9626861763ee13f9d"},
-    {file = "regex-2021.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:32e65442138b7b76dd8173ffa2cf67356b7bc1768851dded39a7a13bf9223da3"},
-    {file = "regex-2021.4.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1e1c20e29358165242928c2de1482fb2cf4ea54a6a6dea2bd7a0e0d8ee321500"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:314d66636c494ed9c148a42731b3834496cc9a2c4251b1661e40936814542b14"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:6d1b01031dedf2503631d0903cb563743f397ccaf6607a5e3b19a3d76fc10480"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:741a9647fcf2e45f3a1cf0e24f5e17febf3efe8d4ba1281dcc3aa0459ef424dc"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:4c46e22a0933dd783467cf32b3516299fb98cfebd895817d685130cc50cd1093"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e512d8ef5ad7b898cdb2d8ee1cb09a8339e4f8be706d27eaa180c2f177248a10"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:980d7be47c84979d9136328d882f67ec5e50008681d94ecc8afa8a65ed1f4a6f"},
-    {file = "regex-2021.4.4-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ce15b6d103daff8e9fee13cf7f0add05245a05d866e73926c358e871221eae87"},
-    {file = "regex-2021.4.4-cp38-cp38-win32.whl", hash = "sha256:a91aa8619b23b79bcbeb37abe286f2f408d2f2d6f29a17237afda55bb54e7aac"},
-    {file = "regex-2021.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:c0502c0fadef0d23b128605d69b58edb2c681c25d44574fc673b0e52dce71ee2"},
-    {file = "regex-2021.4.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:598585c9f0af8374c28edd609eb291b5726d7cbce16be6a8b95aa074d252ee17"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ee54ff27bf0afaf4c3b3a62bcd016c12c3fdb4ec4f413391a90bd38bc3624605"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7d9884d86dd4dd489e981d94a65cd30d6f07203d90e98f6f657f05170f6324c9"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:bf5824bfac591ddb2c1f0a5f4ab72da28994548c708d2191e3b87dd207eb3ad7"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:563085e55b0d4fb8f746f6a335893bda5c2cef43b2f0258fe1020ab1dd874df8"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9c3db21af35e3b3c05764461b262d6f05bbca08a71a7849fd79d47ba7bc33ed"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3916d08be28a1149fb97f7728fca1f7c15d309a9f9682d89d79db75d5e52091c"},
-    {file = "regex-2021.4.4-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:fd45ff9293d9274c5008a2054ecef86a9bfe819a67c7be1afb65e69b405b3042"},
-    {file = "regex-2021.4.4-cp39-cp39-win32.whl", hash = "sha256:fa4537fb4a98fe8fde99626e4681cc644bdcf2a795038533f9f711513a862ae6"},
-    {file = "regex-2021.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:97f29f57d5b84e73fbaf99ab3e26134e6687348e95ef6b48cfd2c06807005a07"},
-    {file = "regex-2021.4.4.tar.gz", hash = "sha256:52ba3d3f9b942c49d7e4bc105bb28551c44065f139a65062ab7912bef10c9afb"},
+    {file = "regex-2021.7.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:494d0172774dc0beeea984b94c95389143db029575f7ca908edd74469321ea99"},
+    {file = "regex-2021.7.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:8cf6728f89b071bd3ab37cb8a0e306f4de897553a0ed07442015ee65fbf53d62"},
+    {file = "regex-2021.7.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1806370b2bef4d4193eebe8ee59a9fd7547836a34917b7badbe6561a8594d9cb"},
+    {file = "regex-2021.7.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:d0cf2651a8804f6325747c7e55e3be0f90ee2848e25d6b817aa2728d263f9abb"},
+    {file = "regex-2021.7.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:268fe9dd1deb4a30c8593cabd63f7a241dfdc5bd9dd0233906c718db22cdd49a"},
+    {file = "regex-2021.7.1-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:7743798dfb573d006f1143d745bf17efad39775a5190b347da5d83079646be56"},
+    {file = "regex-2021.7.1-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:0e46c1191b2eb293a6912269ed08b4512e7e241bbf591f97e527492e04c77e93"},
+    {file = "regex-2021.7.1-cp36-cp36m-win32.whl", hash = "sha256:b1dbeef938281f240347d50f28ae53c4b046a23389cd1fc4acec5ea0eae646a1"},
+    {file = "regex-2021.7.1-cp36-cp36m-win_amd64.whl", hash = "sha256:6c72ebb72e64e9bd195cb35a9b9bbfb955fd953b295255b8ae3e4ad4a146b615"},
+    {file = "regex-2021.7.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bf819c5b77ff44accc9a24e31f1f7ceaaf6c960816913ed3ef8443b9d20d81b6"},
+    {file = "regex-2021.7.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e80d2851109e56420b71f9702ad1646e2f0364528adbf6af85527bc61e49f394"},
+    {file = "regex-2021.7.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a1b6a3f600d6aff97e3f28c34192c9ed93fee293bd96ef327b64adb51a74b2f6"},
+    {file = "regex-2021.7.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ed77b97896312bc2deafe137ca2626e8b63808f5bedb944f73665c68093688a7"},
+    {file = "regex-2021.7.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:a548bb51c4476332ce4139df8e637386730f79a92652a907d12c696b6252b64d"},
+    {file = "regex-2021.7.1-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:210c359e6ee5b83f7d8c529ba3c75ba405481d50f35a420609b0db827e2e3bb5"},
+    {file = "regex-2021.7.1-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:1d386402ae7f3c9b107ae5863f7ecccb0167762c82a687ae6526b040feaa5ac6"},
+    {file = "regex-2021.7.1-cp37-cp37m-win32.whl", hash = "sha256:5049d00dbb78f9d166d1c704e93934d42cce0570842bb1a61695123d6b01de09"},
+    {file = "regex-2021.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:361be4d311ac995a8c7ad577025a3ae3a538531b1f2cf32efd8b7e5d33a13e5a"},
+    {file = "regex-2021.7.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f32f47fb22c988c0b35756024b61d156e5c4011cb8004aa53d93b03323c45657"},
+    {file = "regex-2021.7.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b024ee43ee6b310fad5acaee23e6485b21468718cb792a9d1693eecacc3f0b7e"},
+    {file = "regex-2021.7.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b092754c06852e8a8b022004aff56c24b06310189186805800d09313c37ce1f8"},
+    {file = "regex-2021.7.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a8a5826d8a1b64e2ff9af488cc179e1a4d0f144d11ce486a9f34ea38ccedf4ef"},
+    {file = "regex-2021.7.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:444723ebaeb7fa8125f29c01a31101a3854ac3de293e317944022ae5effa53a4"},
+    {file = "regex-2021.7.1-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:fdad3122b69cdabdb3da4c2a4107875913ac78dab0117fc73f988ad589c66b66"},
+    {file = "regex-2021.7.1-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:4b1999ef60c45357598935c12508abf56edbbb9c380df6f336de38a6c3a294ae"},
+    {file = "regex-2021.7.1-cp38-cp38-win32.whl", hash = "sha256:e07e92935040c67f49571779d115ecb3e727016d42fb36ee0d8757db4ca12ee0"},
+    {file = "regex-2021.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:6b8b629f93246e507287ee07e26744beaffb4c56ed520576deac8b615bd76012"},
+    {file = "regex-2021.7.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:56bef6b414949e2c9acf96cb5d78de8b529c7b99752619494e78dc76f99fd005"},
+    {file = "regex-2021.7.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:78a2a885345a2d60b5e68099e877757d5ed12e46ba1e87507175f14f80892af3"},
+    {file = "regex-2021.7.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3f7a92e60930f8fca2623d9e326c173b7cf2c8b7e4fdcf984b75a1d2fb08114d"},
+    {file = "regex-2021.7.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4fc86b729ab88fe8ac3ec92287df253c64aa71560d76da5acd8a2e245839c629"},
+    {file = "regex-2021.7.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:59845101de68fd5d3a1145df9ea022e85ecd1b49300ea68307ad4302320f6f61"},
+    {file = "regex-2021.7.1-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:ce269e903b00d1ab4746793e9c50a57eec5d5388681abef074d7b9a65748fca5"},
+    {file = "regex-2021.7.1-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c11f2fca544b5e30a0e813023196a63b1cb9869106ef9a26e9dae28bce3e4e26"},
+    {file = "regex-2021.7.1-cp39-cp39-win32.whl", hash = "sha256:1ccbd41dbee3a31e18938096510b7d4ee53aa9fce2ee3dcc8ec82ae264f6acfd"},
+    {file = "regex-2021.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:18040755606b0c21281493ec309214bd61e41a170509e5014f41d6a5a586e161"},
+    {file = "regex-2021.7.1.tar.gz", hash = "sha256:849802379a660206277675aa5a5c327f5c910c690649535863ddf329b0ba8c87"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
     {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-typed-ast = [
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2068531575a125b87a41802130fa7e29f26c09a2833fea68d9a40cf33902eba6"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c907f561b1e83e93fad565bac5ba9c22d96a54e7ea0267c708bffe863cbe4075"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1b3ead4a96c9101bef08f9f7d1217c096f31667617b58de957f690c92378b528"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-win32.whl", hash = "sha256:dde816ca9dac1d9c01dd504ea5967821606f02e510438120091b84e852367428"},
-    {file = "typed_ast-1.4.3-cp35-cp35m-win_amd64.whl", hash = "sha256:777a26c84bea6cd934422ac2e3b78863a37017618b6e5c08f92ef69853e765d3"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8afcf15cc511ada719a88e013cec87c11aff7b91f019295eb4530f96fe5ef2f"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:52b1eb8c83f178ab787f3a4283f68258525f8d70f778a2f6dd54d3b5e5fb4341"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:01ae5f73431d21eead5015997ab41afa53aa1fbe252f9da060be5dad2c730ace"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c190f0899e9f9f8b6b7863debfb739abcb21a5c054f911ca3596d12b8a4c4c7f"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-win32.whl", hash = "sha256:398e44cd480f4d2b7ee8d98385ca104e35c81525dd98c519acff1b79bdaac363"},
-    {file = "typed_ast-1.4.3-cp36-cp36m-win_amd64.whl", hash = "sha256:bff6ad71c81b3bba8fa35f0f1921fb24ff4476235a6e94a26ada2e54370e6da7"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0fb71b8c643187d7492c1f8352f2c15b4c4af3f6338f21681d3681b3dc31a266"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:760ad187b1041a154f0e4d0f6aae3e40fdb51d6de16e5c99aedadd9246450e9e"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5feca99c17af94057417d744607b82dd0a664fd5e4ca98061480fd8b14b18d04"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:95431a26309a21874005845c21118c83991c63ea800dd44843e42a916aec5899"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-win32.whl", hash = "sha256:aee0c1256be6c07bd3e1263ff920c325b59849dc95392a05f258bb9b259cf39c"},
-    {file = "typed_ast-1.4.3-cp37-cp37m-win_amd64.whl", hash = "sha256:9ad2c92ec681e02baf81fdfa056fe0d818645efa9af1f1cd5fd6f1bd2bdfd805"},
-    {file = "typed_ast-1.4.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b36b4f3920103a25e1d5d024d155c504080959582b928e91cb608a65c3a49e1a"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:067a74454df670dcaa4e59349a2e5c81e567d8d65458d480a5b3dfecec08c5ff"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7538e495704e2ccda9b234b82423a4038f324f3a10c43bc088a1636180f11a41"},
-    {file = "typed_ast-1.4.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:af3d4a73793725138d6b334d9d247ce7e5f084d96284ed23f22ee626a7b88e39"},
-    {file = "typed_ast-1.4.3-cp38-cp38-win32.whl", hash = "sha256:f2362f3cb0f3172c42938946dbc5b7843c2a28aec307c49100c8b38764eb6927"},
-    {file = "typed_ast-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:dd4a21253f42b8d2b48410cb31fe501d32f8b9fbeb1f55063ad102fe9c425e40"},
-    {file = "typed_ast-1.4.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f328adcfebed9f11301eaedfa48e15bdece9b519fb27e6a8c01aa52a17ec31b3"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2c726c276d09fc5c414693a2de063f521052d9ea7c240ce553316f70656c84d4"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:cae53c389825d3b46fb37538441f75d6aecc4174f615d048321b716df2757fb0"},
-    {file = "typed_ast-1.4.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b9574c6f03f685070d859e75c7f9eeca02d6933273b5e69572e5ff9d5e3931c3"},
-    {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
-    {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
-    {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
 ]
 typing-extensions = [
     {file = "typing_extensions-3.10.0.0-py2-none-any.whl", hash = "sha256:0ac0f89795dd19de6b97debb0c6af1c70987fd80a2d62d1958f7e56fcc31b497"},

--- a/coveo-functools/pyproject.toml
+++ b/coveo-functools/pyproject.toml
@@ -18,7 +18,7 @@ typing_extensions = "*"
 attrs = "*"
 black = { version = "21.6b0", allow-prereleases = true }
 coveo-testing = { path = "../coveo-testing/", develop = true }
-mypy = "0.812"
+mypy = "0.910"
 
 
 [tool.stew.ci]

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -48,6 +48,7 @@ def _flex_mocks() -> Generator[Any, None, None]:
     yield mock_function
 
 
+@UnitTest
 @parametrize("obj", _flex_mocks())
 def test_flex_raw_data(obj: Any) -> None:
     result = obj(**PAYLOAD)
@@ -212,6 +213,7 @@ def _flex_on_flex_classes() -> Generator[Type, None, None]:
     yield OuterClass
 
 
+@UnitTest
 @parametrize("obj", _flex_on_flex_classes())
 def test_flex_on_flex(obj: Type) -> None:
     assert obj(**PAYLOAD).inner.value == EXPECTED_VALUE

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -1,10 +1,9 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Final, Dict, Any, Optional, Union
 
 import pytest
 from coveo_functools.exceptions import InvalidUnion
 from coveo_functools.flex import FlexFactory
-from coveo_testing.parametrize import parametrize
 from coveo_testing.markers import UnitTest
 
 
@@ -192,3 +191,40 @@ def test_flex_factory_raise_not_set() -> None:
 
     with pytest.raises(TypeError):
         _ = FlexFactory(MockUnion)()
+
+
+def test_flex_factory_decorator() -> None:
+    @FlexFactory
+    class Test:
+        def __init__(self, test: str) -> None:
+            self.test = test
+
+    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
+
+
+def test_flex_factory_decorator_dataclass() -> None:
+    @FlexFactory
+    @dataclass
+    class Test:
+        def __init__(self, test: str) -> None:
+            self.test = test
+
+    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
+
+
+def test_flex_factory_decorator_alt() -> None:
+    @FlexFactory()
+    class Test:
+        def __init__(self, test: str) -> None:
+            self.test = test
+
+    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
+
+
+def test_flex_factory_decorator_alt_with_params() -> None:
+    @FlexFactory(strip_extras=True)
+    class Test:
+        def __init__(self, test: str) -> None:
+            self.test = test
+
+    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -8,6 +8,9 @@ from coveo_testing.markers import UnitTest
 @dataclass
 class MockLeaf:
     object_id: str
+    _int: int
+    _float: float
+    _bool: bool
 
 
 @dataclass
@@ -27,7 +30,10 @@ MOCK_PAYLOAD: Final[Dict[str, Any]] = {
     "iNNer": {
         "ObjectId": "inner",
         "inner": {
-            "_object__id": "leaf"
+            "_object__id": "leaf",
+            "int": 1,
+            "float": 1.2,
+            "bool": True,
         }
     }
 }
@@ -39,6 +45,9 @@ def test_flex_factory_detect_and_recurse_objects() -> None:
     assert instance.object_id == 'outer'
     assert instance.inner.object_id == 'inner'
     assert instance.inner.inner.object_id == 'leaf'
+    assert instance.inner.inner._int == 1
+    assert instance.inner.inner._float == 1.2
+    assert instance.inner.inner._bool is True
 
     assert isinstance(instance, MockOuter)
     assert isinstance(instance.inner, MockInner)

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -1,14 +1,224 @@
 from dataclasses import dataclass
-from typing import Final, Dict, Any, Optional, Union
+from typing import Final, Dict, Any, Optional, Union, Callable, Generator, Type, Protocol
 
 import pytest
 from coveo_functools.exceptions import AmbiguousAnnotation
 from coveo_functools.flex import flex, RAW_KEY
 from coveo_testing.markers import UnitTest
+from coveo_testing.parametrize import parametrize
+
+
+@dataclass
+class MockInner:
+    value: str
+
+
+EXPECTED_VALUE = "SUCCESS"
+EXPECTED_VALUE_PAYLOAD = {"Value": EXPECTED_VALUE}
+PAYLOAD: Final[Dict[str, Any]] = {"Inner": EXPECTED_VALUE_PAYLOAD}
+EXPECTED_INNER: Final[MockInner] = MockInner(EXPECTED_VALUE)
+
+
+def _flex_mocks() -> Generator[Any, None, None]:
+    """General set of mocks meant to be called with PAYLOAD."""
+
+    @flex
+    class MockClass:
+        def __init__(self, inner: MockInner) -> None:
+            self.inner = inner
+
+        @flex
+        def mock_method(self, inner: MockInner) -> MockInner:
+            return inner
+
+    yield MockClass
+    yield MockClass(EXPECTED_INNER).mock_method
+
+    @flex
+    @dataclass
+    class MockDataClass:
+        inner: MockInner
+
+    yield MockDataClass
+
+    @flex
+    def mock_function(inner: MockInner) -> MockInner:
+        return inner
+
+    yield mock_function
+
+
+@parametrize("obj", _flex_mocks())
+def test_flex_raw_data(obj: Any) -> None:
+    result = obj(**PAYLOAD)
+    assert getattr(result, RAW_KEY) == PAYLOAD
 
 
 @UnitTest
-def test_flex_factory_detect_and_recurse_objects() -> None:
+def test_flex_unions() -> None:
+    @dataclass
+    class MockUnion:
+        union: Optional[Union[bool, float]]
+
+    assert flex(MockUnion)(**{"union": True}).union is True
+    assert flex(MockUnion)(**{"union": 1.2}).union == 1.2
+    assert flex(MockUnion)(**{"union": None}).union is None
+
+
+@UnitTest
+def test_flex_invalid_union() -> None:
+    """Unions must be comprised of select builtin types only, else it may become ambiguous."""
+
+    @dataclass
+    class MockUnion:
+        union: Union[str, object]
+
+    with pytest.raises(AmbiguousAnnotation):
+        _ = flex(MockUnion)(**{"union": "sorry"})
+
+
+@UnitTest
+def test_flex_defaults() -> None:
+    @dataclass
+    class MockUnion:
+        none: Optional[str] = None
+        not_none: Optional[str] = "set"
+
+    assert flex(MockUnion)().none is None
+    assert flex(MockUnion)().not_none is not None
+
+
+@UnitTest
+def test_flex_raise_not_set() -> None:
+    @dataclass
+    class MockUnion:
+        missing: Optional[str]
+
+    with pytest.raises(TypeError):
+        _ = flex(MockUnion)()  # type: ignore[call-arg]
+
+
+class TestInterface(Protocol):
+    """Just a trick for annotations"""
+
+    value: str
+
+    def __init__(self, value: str) -> None:
+        ...
+
+
+def _class_decorator_styles() -> Generator[Type[TestInterface], None, None]:
+    @flex
+    class ClassNoParenthesis:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    yield ClassNoParenthesis
+
+    @flex()
+    class ClassWithParenthesis:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    yield ClassWithParenthesis
+
+    @flex
+    @dataclass
+    class DataclassNoParenthesis:
+        value: str
+
+    yield DataclassNoParenthesis
+
+    @flex()
+    @dataclass
+    class DataclassWithParenthesis:
+        value: str
+
+    yield DataclassWithParenthesis
+
+
+@UnitTest
+@parametrize("obj", _class_decorator_styles())
+def test_flex_decorator_class(obj: Type[TestInterface]) -> None:
+    """Ensures that different class decorator styles work with
+    **, as well as direct/typical usage.
+    """
+    assert obj(**EXPECTED_VALUE_PAYLOAD).value == EXPECTED_VALUE
+    assert obj(EXPECTED_VALUE).value == EXPECTED_VALUE
+
+
+def _function_decorator_styles() -> Generator[Callable[[str], str], None, None]:
+    @flex
+    def no_parenthesis(value: str) -> str:
+        return value
+
+    yield no_parenthesis
+
+    @flex()
+    def with_parenthesis(value: str) -> str:
+        return value
+
+    yield with_parenthesis
+
+    @dataclass
+    class MethodNoParenthesis:
+        @flex
+        def method(self, value: str) -> str:
+            return value
+
+    yield MethodNoParenthesis().method
+
+    @dataclass
+    class MethodWithParenthesis:
+        @flex()
+        def method(self, value: str) -> str:
+            return value
+
+    yield MethodWithParenthesis().method
+
+
+@UnitTest
+@parametrize("fn", _function_decorator_styles())
+def test_flex_function_decorator_styles(fn: Callable[..., str]) -> None:
+    assert fn(**EXPECTED_VALUE_PAYLOAD) == EXPECTED_VALUE
+    assert fn(EXPECTED_VALUE) == EXPECTED_VALUE
+
+
+def _flex_on_flex_classes() -> Generator[Type, None, None]:
+    """Flex should be able to handle flex-decorated things too."""
+
+    @flex
+    @dataclass
+    class InnerDataclass:
+        value: str
+
+    @flex
+    @dataclass
+    class OuterDataclass:
+        inner: InnerDataclass
+
+    yield OuterDataclass
+
+    @flex
+    class InnerClass:
+        def __init__(self, value: str) -> None:
+            self.value = value
+
+    @flex
+    class OuterClass:
+        def __init__(self, inner: InnerClass) -> None:
+            self.inner = inner
+
+    yield OuterClass
+
+
+@parametrize("obj", _flex_on_flex_classes())
+def test_flex_on_flex(obj: Type) -> None:
+    assert obj(**PAYLOAD).inner.value == EXPECTED_VALUE
+
+
+@UnitTest
+def test_flex_recurse_into_objects() -> None:
     @dataclass
     class MockLeaf:
         object_id: str
@@ -55,187 +265,5 @@ def test_flex_factory_detect_and_recurse_objects() -> None:
     assert leaf._float == 1.2
     assert leaf._bool is True
     assert leaf.optional_str is None
-    assert not hasattr(leaf, "stripped")
+    assert not hasattr(leaf, "extra")
     assert isinstance(leaf, MockLeaf)
-
-
-@UnitTest
-def test_flex_factory_raw() -> None:
-    """The raw data is injected inside the instance."""
-
-    class MockTest:
-        raw: Dict[str, Any]
-
-        def __init__(self, test: str) -> None:
-            self.test = test
-
-    payload = {"_test": "raw"}
-    instance = flex(MockTest)(**payload)
-    assert getattr(instance, RAW_KEY) == payload
-
-
-@UnitTest
-def test_flex_factory_raw_constructor() -> None:
-    """If the raw key is in the constructor, use it."""
-
-    @dataclass
-    class MockTest:
-        test: str
-        _flexed_from_: Dict[str, Any]
-
-    payload = {"_test": "raw"}
-    instance = flex(MockTest)(**payload)
-    assert instance._flexed_from_ == payload
-
-
-@UnitTest
-def test_flex_factory_unions() -> None:
-    @dataclass
-    class MockUnion:
-        union: Optional[Union[bool, float]]
-
-    assert flex(MockUnion)(**{"union": True}).union is True
-    assert flex(MockUnion)(**{"union": 1.2}).union == 1.2
-    assert flex(MockUnion)(**{"union": None}).union is None
-
-
-@UnitTest
-def test_flex_factory_invalid_union() -> None:
-    """Unions must be comprised of select builtin types only, else it may become ambiguous."""
-
-    @dataclass
-    class MockUnion:
-        union: Union[str, object]
-
-    with pytest.raises(AmbiguousAnnotation):
-        _ = flex(MockUnion)(**{"union": "sorry"})
-
-
-@UnitTest
-def test_flex_factory_defaults() -> None:
-    @dataclass
-    class MockUnion:
-        none: Optional[str] = None
-        not_none: Optional[str] = "set"
-
-    assert flex(MockUnion)().none is None
-    assert flex(MockUnion)().not_none is not None
-
-
-@UnitTest
-def test_flex_factory_raise_not_set() -> None:
-    @dataclass
-    class MockUnion:
-        missing: Optional[str]
-
-    with pytest.raises(TypeError):
-        _ = flex(MockUnion)()
-
-
-@UnitTest
-def test_flex_factory_decorator_class() -> None:
-    @flex
-    class Test:
-        def __init__(self, test: str) -> None:
-            self.test = test
-
-    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
-
-
-@UnitTest
-def test_flex_factory_decorator_class_alt() -> None:
-    @flex()
-    class Test:
-        def __init__(self, test: str) -> None:
-            self.test = test
-
-    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
-
-
-@UnitTest
-def test_flex_factory_decorator_alt_with_params() -> None:
-    @flex()
-    class Test:
-        def __init__(self, test: str) -> None:
-            self.test = test
-
-    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
-
-
-@UnitTest
-def test_flex_factory_decorator_dataclass() -> None:
-    @flex
-    @dataclass
-    class Test:
-        def __init__(self, test: str) -> None:
-            self.test = test
-
-    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
-
-
-@UnitTest
-def test_flex_factory_decorator_dataclass_alt() -> None:
-    @flex()
-    @dataclass
-    class Test:
-        def __init__(self, test: str) -> None:
-            self.test = test
-
-    assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
-
-
-@UnitTest
-def test_flex_factory_decorator_function() -> None:
-    @flex
-    def fn(arg1: str) -> str:
-        return arg1
-
-    assert fn(**{"ARG1": "yay"}) == "yay"
-
-
-@UnitTest
-def test_flex_factory_decorator_function_alt() -> None:
-    @flex()
-    def fn(arg1: str) -> str:
-        return arg1
-
-    assert fn(**{"ARG1": "yay"}) == "yay"
-
-
-@UnitTest
-def test_flex_factory_decorator_method() -> None:
-    @dataclass
-    class Test:
-        value: str
-
-        @flex
-        def method1(self, arg: str) -> str:
-            return self.value + arg
-
-    assert Test("he").method1(**{"ARG": "llo"}) == "hello"
-
-
-@UnitTest
-def test_flex_factory_decorator_method_alt() -> None:
-    @dataclass
-    class Test:
-        value: str
-
-        @flex()
-        def method1(self, arg: str) -> str:
-            return self.value + arg
-
-    assert Test("he").method1(**{"ARG": "llo"}) == "hello"
-
-
-def test_flex_factory_normal_use() -> None:
-    @dataclass
-    class Test:
-        value: str
-
-        @flex()
-        def method1(self, arg: str) -> str:
-            return self.value + arg
-
-    assert Test("he").method1("llo") == "hello"
-    assert Test(value="he").method1(arg="llo") == "hello"

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -67,13 +67,14 @@ def test_flex_factory_detect_and_recurse_objects() -> None:
 @UnitTest
 def test_flex_factory_raw() -> None:
     """A class can be annotated with the raw node."""
+
     class MockRaw:
         raw: Dict[str, Any]
 
         def __init__(self, test: str) -> None:
             self.test = test
 
-    payload = {'_test': 'raw'}
+    payload = {"_test": "raw"}
     instance = FlexFactory(MockRaw, keep_raw="raw")(**payload)
     assert instance.raw == payload
 
@@ -81,12 +82,13 @@ def test_flex_factory_raw() -> None:
 @UnitTest
 def test_flex_factory_raw_dataclass() -> None:
     """A dataclass can be annotated with the raw node."""
+
     @dataclass
     class MockRaw:
         test: str
         raw: Dict[str, Any]
 
-    payload = {'_test': 'raw'}
+    payload = {"_test": "raw"}
     instance = FlexFactory(MockRaw, keep_raw="raw")(**payload)
     assert instance.raw == payload
 
@@ -94,11 +96,12 @@ def test_flex_factory_raw_dataclass() -> None:
 @UnitTest
 def test_flex_factory_raw_non_annotated() -> None:
     """The raw attribute works even when the class doesn't annotate it."""
+
     class MockRaw:
         def __init__(self, test: str) -> None:
             self.test = test
 
-    payload = {'_test': 'raw'}
+    payload = {"_test": "raw"}
     instance = FlexFactory(MockRaw, keep_raw="raw")(**payload)
     assert instance.raw == payload  # type: ignore[attr-defined]
 
@@ -106,11 +109,12 @@ def test_flex_factory_raw_non_annotated() -> None:
 @UnitTest
 def test_flex_factory_raw_dataclass_non_annotated() -> None:
     """The raw attribute works even when the class doesn't annotate it."""
+
     @dataclass
     class MockRaw:
         test: str
 
-    payload = {'_test': 'raw'}
+    payload = {"_test": "raw"}
     instance = FlexFactory(MockRaw, keep_raw="raw")(**payload)
     assert instance.raw == payload  # type: ignore[attr-defined]
 
@@ -118,12 +122,13 @@ def test_flex_factory_raw_dataclass_non_annotated() -> None:
 @UnitTest
 def test_flex_factory_doesnt_override_explicit_raw() -> None:
     """If the raw data is explicitly given, don't overwrite it."""
+
     @dataclass
     class MockRaw:
         test: str
 
     expected = {"explicitly": "given"}
-    payload = {'test': 'raw', 'raw_data': expected}
+    payload = {"test": "raw", "raw_data": expected}
     instance = FlexFactory(MockRaw, keep_raw="raw_data")(**payload)
 
     assert instance.raw_data == expected  # type: ignore[attr-defined]
@@ -132,16 +137,17 @@ def test_flex_factory_doesnt_override_explicit_raw() -> None:
 @UnitTest
 def test_flex_factory_doesnt_override_explicit_raw_with_constructor() -> None:
     """If the raw data is explicitly given, don't overwrite it."""
+
     @dataclass
     class MockRaw:
         test: str
         raw_data: Dict[str, Any]
 
     expected = {"explicitly": "given"}
-    payload = {'test': 'raw', 'raw_data': expected}
+    payload = {"test": "raw", "raw_data": expected}
     instance = FlexFactory(MockRaw, keep_raw="raw_data")(**payload)
 
-    assert instance.raw_data == expected  # type: ignore[attr-defined]
+    assert instance.raw_data == expected
 
 
 @UnitTest

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -228,3 +228,11 @@ def test_flex_factory_decorator_alt_with_params() -> None:
             self.test = test
 
     assert Test(**{"TEST": "SUCCESS"}).test == "SUCCESS"
+
+
+def test_flex_factory_function() -> None:
+    @FlexFactory
+    def fn(arg1: str) -> str:
+        return arg1
+
+    assert fn(**{"ARG1": "yay"}) == "yay"

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -38,59 +38,65 @@ MOCK_PAYLOAD: Final[Dict[str, Any]] = {
             "float": 1.2,
             "bool": True,
             "optional-str": None,
-            "extra": "this value is stripped out."
-        }
-    }
+            "extra": "this value is stripped out.",
+        },
+    },
 }
 
 
 @UnitTest
 def test_flex_factory_detect_and_recurse_objects() -> None:
     instance = FlexFactory(MockOuter)(**MOCK_PAYLOAD)
-    assert instance.object_id == 'outer'
+    assert instance.object_id == "outer"
     assert isinstance(instance, MockOuter)
 
-    assert instance.inner.object_id == 'inner'
+    assert instance.inner.object_id == "inner"
     assert isinstance(instance.inner, MockInner)
 
     leaf = instance.inner.inner
-    assert leaf.object_id == 'leaf'
+    assert leaf.object_id == "leaf"
     assert leaf._int == 1
     assert leaf._float == 1.2
     assert leaf._bool is True
     assert leaf.optional_str is None
-    assert not hasattr(leaf, 'stripped')
+    assert not hasattr(leaf, "stripped")
     assert isinstance(leaf, MockLeaf)
 
 
 @UnitTest
 def test_flex_factory_raw() -> None:
-    instance = FlexFactory(MockOuter, keep_raw='_raw')(**MOCK_PAYLOAD)
-    assert instance._raw == MOCK_PAYLOAD
-    assert instance.inner.inner._raw == MOCK_PAYLOAD['iNNer']['inner']
+    class MockRaw:
+        _raw: Dict[str, Any]
+
+        def __init__(self, test: str) -> None:
+            self.test = test
+
+    payload = {'_test': 'raw'}
+    instance = FlexFactory(MockRaw, keep_raw="_raw")(**payload)
+    assert instance._raw == payload
 
 
 @UnitTest
 def test_flex_factory_unions() -> None:
-
     @dataclass
     class MockUnion:
         union: Optional[Union[bool, float]]
 
-    assert FlexFactory(MockUnion)(**{'union': True}).union is True
-    assert FlexFactory(MockUnion)(**{'union': 1.2}).union == 1.2
-    assert FlexFactory(MockUnion)(**{'union': None}).union is None
+    assert FlexFactory(MockUnion)(**{"union": True}).union is True
+    assert FlexFactory(MockUnion)(**{"union": 1.2}).union == 1.2
+    assert FlexFactory(MockUnion)(**{"union": None}).union is None
 
 
 @UnitTest
 def test_flex_factory_invalid_union() -> None:
     """Unions must be comprised of builtin types only, else it may become ambiguous."""
+
     @dataclass
     class MockUnion:
         union: Union[str, MockLeaf]
 
     with pytest.raises(InvalidUnion):
-        _ = FlexFactory(MockUnion)(**{'union': 'sorry'})
+        _ = FlexFactory(MockUnion)(**{"union": "sorry"})
 
 
 @UnitTest
@@ -98,7 +104,7 @@ def test_flex_factory_defaults() -> None:
     @dataclass
     class MockUnion:
         none: Optional[str] = None
-        not_none: Optional[str] = 'set'
+        not_none: Optional[str] = "set"
 
     assert FlexFactory(MockUnion)().none is None
     assert FlexFactory(MockUnion)().not_none is not None

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -91,3 +91,24 @@ def test_flex_factory_invalid_union() -> None:
 
     with pytest.raises(InvalidUnion):
         _ = FlexFactory(MockUnion)(**{'union': 'sorry'})
+
+
+@UnitTest
+def test_flex_factory_defaults() -> None:
+    @dataclass
+    class MockUnion:
+        none: Optional[str] = None
+        not_none: Optional[str] = 'set'
+
+    assert FlexFactory(MockUnion)().none is None
+    assert FlexFactory(MockUnion)().not_none is not None
+
+
+@UnitTest
+def test_flex_factory_raise_not_set() -> None:
+    @dataclass
+    class MockUnion:
+        missing: Optional[str]
+
+    with pytest.raises(TypeError):
+        _ = FlexFactory(MockUnion)()

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import Final, Dict, Any, Union
+
+from coveo_functools.flex import FlexFactory
+from coveo_testing.markers import UnitTest
+
+
+@dataclass
+class MockLeaf:
+    object_id: str
+
+
+@dataclass
+class MockInner:
+    object_id: str
+    inner: MockLeaf
+
+
+@dataclass
+class MockOuter:
+    object_id: str
+    inner: MockInner
+
+
+MOCK_PAYLOAD: Final[Dict[str, Any]] = {
+    "object-id": "outer",
+    "iNNer": {
+        "ObjectId": "inner",
+        "inner": {
+            "_object__id": "leaf"
+        }
+    }
+}
+
+
+@UnitTest
+def test_flex_factory_detect_and_recurse_objects() -> None:
+    instance = FlexFactory(MockOuter)(**MOCK_PAYLOAD)
+    assert instance.object_id == 'outer'
+    assert instance.inner.object_id == 'inner'
+    assert instance.inner.inner.object_id == 'leaf'
+
+    assert isinstance(instance, MockOuter)
+    assert isinstance(instance.inner, MockInner)
+    assert isinstance(instance.inner.inner, MockLeaf)


### PR DESCRIPTION
## NOTE: IF YOU DIDN'T REVIEW THIS YET, JUST GO AND REVIEW #78 INSTEAD.

So, as I was playing with the Github API I wanted to be able to transform their responses into annotated classes, and while typed dicts are a thing, I really prefer a pep8-dataclass-driven approach.

So I set up to improve the `@flexcase` decorator with some sort of deserializer, and this is the result. It's a huge improvement so it will become the main decorator so that people rarely have to use `flexcase` or `unflex` anymore.

I guess you should start by the readme and maybe the tests.

I was finally able to tackle down the decorator parenthesis problem. This decorator can be used with or without them! 🥳 

Other features on the way:
- support for lists
- support for obj-or-list-of-obj (i.e.: `Union[T, List[T]]`)
- support for maps
- support for sets (we would convert the json list to a set if the annotation told us so)
- support for more typing interfaces (Collection, Sequence, Mapping, Iterable, etc)

All of those features will change how the `_convert` function is coded. I'm saying right now, because it's a little messy currently. With all the types and conditions, there will probably some sort of dispatch/deserializer approach that will cut the whole middle part of that function into smaller, type-specific bits.