### PR TITLE
feature // (PART OF #78) adding list support and cleaning up

### DIFF
--- a/coveo-functools/coveo_functools/casing.py
+++ b/coveo-functools/coveo_functools/casing.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from typing import Match, Iterable, Dict, Callable, Any, TypeVar, Mapping, Type, cast
+from typing import Match, Iterable, Dict, Callable, Any, TypeVar, Mapping, Type
 
 import inflection
 

--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -2,9 +2,9 @@ class CoveoFunctoolsException(Exception):
     """Base class for coveo-functools exceptions."""
 
 
-class FlexException(CoveoFunctoolsException):
+class Flexception(CoveoFunctoolsException):  # sorry for the pun :socanadian:
     """Base class for exceptions raised by the flex module."""
 
 
-class UnsupportedAnnotation(FlexException, NotImplementedError):
+class UnsupportedAnnotation(Flexception, NotImplementedError):
     """When an annotation isn't suported."""

--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -6,5 +6,5 @@ class FlexException(CoveoFunctoolsException):
     """Base class for exceptions raised by the flex module."""
 
 
-class AmbiguousAnnotation(FlexException):
-    """An invalid union was provided."""
+class UnsupportedAnnotation(FlexException, NotImplementedError):
+    """When an annotation isn't suported."""

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -17,16 +17,20 @@ from typing import (
     overload,
     Final,
     cast,
+    List,
 )
 
 from coveo_functools.annotations import find_annotations
 from coveo_functools.casing import unflex, flexcase
-from coveo_functools.exceptions import AmbiguousAnnotation, FlexException
+from coveo_functools.dispatch import dispatch
+from coveo_functools.exceptions import FlexException, UnsupportedAnnotation
 
 _ = unflex, flexcase  # mark them as used (forward compatibility vs docs)
 
 
-JSON_TYPES = (str, bool, int, float, type(None))
+JSON_TYPES = (str, bool, int, float, type(None))  # list omitted to support list of custom types
+PASSTHROUGH_TYPES = {dict, None, Any, *JSON_TYPES}  # todo: do we really need both?
+
 META_TYPES = (Union, Optional)
 
 T = TypeVar("T")
@@ -36,102 +40,6 @@ Wrapper = Callable[..., T]
 Delegate = Callable[[SupportedTypes], Wrapper]
 
 RAW_KEY: Final[str] = "_flexed_from_"
-
-
-def _convert(
-    arguments: Dict[str, Type],
-    mapped_kwargs: Dict[str, Any],
-) -> Generator[Tuple[str, Any], None, None]:
-
-    # scan the arguments for custom types and convert them
-    for arg_name, arg_type in arguments.items():
-        if arg_name not in mapped_kwargs:
-            continue  # skip it; this may be ok if the target class has a default value for this arg
-
-        elif arg_type in JSON_TYPES:
-            # assume that builtin types are already converted
-            arg_value = mapped_kwargs[arg_name]
-
-        else:
-            # check for special typing constructs
-            meta_type = get_origin(arg_type)
-            if meta_type in (Optional, Union):
-                allowed_types = list(get_args(arg_type))
-                if all(_type in JSON_TYPES for _type in allowed_types):
-                    # all types are builtin, we expect it to be already ok; carry on
-                    arg_value = mapped_kwargs[arg_name]
-                else:
-                    while type(None) in allowed_types:
-                        allowed_types.remove(type(None))
-
-                    if not allowed_types:
-                        # not sure if this is even possible... Union[None, None] ?
-                        arg_value = mapped_kwargs[arg_name]
-                    elif len(allowed_types) > 1:
-                        # todo: we should allow things like Union[T, List[T]] (one or many)
-                        raise AmbiguousAnnotation(meta_type)
-                    else:
-                        arg_value = flex(allowed_types[0])(**mapped_kwargs[arg_name])
-
-            # elif meta_type in (List, Set, Iterable, Collection, Sequence):
-            #     ...  # handle lists/etc
-            # elif meta_type in (Dict, Mapping, MutableMapping):
-            #     ...  # handle mappings
-
-            elif meta_type:
-                raise FlexException(f"Unsupported type: {meta_type}")
-
-            else:
-                arg_value = flex(arg_type)(**mapped_kwargs[arg_name])
-
-        # convert the argument to the target class
-        yield arg_name, arg_value
-
-
-def _remap_and_convert(obj: SupportedTypes, dirty_kwargs: Dict[str, Any]) -> Dict[str, Any]:
-    mapped_kwargs = unflex(obj, dirty_kwargs)
-    return dict(_convert(find_annotations(obj), mapped_kwargs))
-
-
-@overload
-def _generate_wrapper(obj: Type[T]) -> Type[T]:
-    ...
-
-
-@overload
-def _generate_wrapper(obj: Callable[..., T]) -> Callable[..., T]:
-    ...
-
-
-def _generate_wrapper(obj: Union[Type[T], Callable[..., T]]) -> Union[Type[T], Callable[..., T]]:
-    """Returns a wrapper over _flex_call to please Python's mechanics."""
-    if inspect.isclass(obj):
-        return _generate_class_wrapper(cast(Type[T], obj))
-
-    return _generate_callable_wrapper(cast(Callable[..., T], obj))
-
-
-def _generate_callable_wrapper(obj: Callable[..., T]) -> Callable[..., T]:
-    @functools.wraps(obj)
-    def wrapper(*args: Any, **kwargs: Any) -> T:
-        value = obj(*args, **_remap_and_convert(obj, kwargs))
-        if hasattr(value, "__dict__"):
-            value.__dict__[RAW_KEY] = kwargs
-        return value
-
-    return wrapper
-
-
-def _generate_class_wrapper(obj: Type[T]) -> Type[T]:
-    fn = obj.__init__
-
-    @functools.wraps(fn)
-    def new_init(*args: Any, **kwargs: Any) -> None:
-        setattr(args[0], RAW_KEY, kwargs)  # set the raw data on self
-        fn(*args, **_remap_and_convert(fn, kwargs))
-
-    obj.__init__ = new_init  # type: ignore[assignment]
-    return obj
 
 
 @overload
@@ -196,3 +104,310 @@ def flex(obj: Optional[SupportedTypes] = None) -> Union[Wrapper, Delegate]:
 
         # python's mechanic is going to call us again with the obj as the first (and only) argument to get a wrapper.
         return flex
+
+
+@overload
+def _generate_wrapper(obj: Type[T]) -> Type[T]:
+    ...
+
+
+@overload
+def _generate_wrapper(obj: Callable[..., T]) -> Callable[..., T]:
+    ...
+
+
+def _generate_wrapper(obj: Union[Type[T], Callable[..., T]]) -> Union[Type[T], Callable[..., T]]:
+    """Returns a wrapper over _flex_call to please Python's mechanics."""
+    if inspect.isclass(obj):
+        return _generate_class_wrapper(cast(Type[T], obj))
+
+    return _generate_callable_wrapper(cast(Callable[..., T], obj))
+
+
+def _generate_callable_wrapper(obj: Callable[..., T]) -> Callable[..., T]:
+    @functools.wraps(obj)
+    def wrapper(*args: Any, **kwargs: Any) -> T:
+        value = obj(*args, **_remap_and_convert(obj, kwargs))
+        if hasattr(value, "__dict__"):
+            value.__dict__[RAW_KEY] = kwargs
+        return value
+
+    return wrapper
+
+
+def _generate_class_wrapper(obj: Type[T]) -> Type[T]:
+    fn = obj.__init__
+
+    @functools.wraps(fn)
+    def new_init(*args: Any, **kwargs: Any) -> None:
+        setattr(args[0], RAW_KEY, kwargs)  # set the raw data on self
+        fn(*args, **_remap_and_convert(fn, kwargs))
+
+    obj.__init__ = new_init  # type: ignore[assignment]
+    return obj
+
+
+def _convert(
+    arguments: Dict[str, Type],
+    mapped_kwargs: Dict[str, Any],
+) -> Generator[Tuple[str, Any], None, None]:
+
+    # scan the arguments for custom types and convert them
+    for arg_name, arg_type in arguments.items():
+        if arg_name not in mapped_kwargs:
+            continue  # skip it; this may be ok if the target class has a default value for this arg
+
+        elif arg_type in JSON_TYPES:
+            # assume that builtin types are already converted
+            arg_value = mapped_kwargs[arg_name]
+
+        else:
+            # check for special typing constructs
+            meta_type = get_origin(arg_type)
+            if meta_type in (Optional, Union):
+                allowed_types = list(get_args(arg_type))
+                if all(_type in JSON_TYPES for _type in allowed_types):
+                    # all types are builtin, we expect it to be already ok; carry on
+                    arg_value = mapped_kwargs[arg_name]
+                else:
+                    while type(None) in allowed_types:
+                        allowed_types.remove(type(None))
+
+                    if not allowed_types:
+                        # not sure if this is even possible... Union[None, None] ?
+                        arg_value = mapped_kwargs[arg_name]
+                    elif len(allowed_types) > 1:
+                        # todo: we should allow things like Union[T, List[T]] (one or many)
+                        raise UnsupportedAnnotation(meta_type)
+                    else:
+                        arg_value = flex(allowed_types[0])(**mapped_kwargs[arg_name])
+
+            # elif meta_type in (List, Set, Iterable, Collection, Sequence):
+            #     ...  # handle lists/etc
+            # elif meta_type in (Dict, Mapping, MutableMapping):
+            #     ...  # handle mappings
+
+            elif meta_type:
+                raise FlexException(f"Unsupported type: {meta_type}")
+
+            else:
+                arg_value = flex(arg_type)(**mapped_kwargs[arg_name])
+
+        # convert the argument to the target class
+        yield arg_name, arg_value
+
+
+def _remap_and_convert(obj: SupportedTypes, dirty_kwargs: Dict[str, Any]) -> Dict[str, Any]:
+    mapped_kwargs = unflex(obj, dirty_kwargs)
+    return dict(_convert(find_annotations(obj), mapped_kwargs))
+
+
+def _resolve_hint(thing: Type) -> Tuple[Type, Tuple[Type, ...]]:
+    """
+    Transform e.g. List[Union[str, bool]] into (list, Union[str, bool]).
+    Also validates that the annotation is supported and removes "NoneType" if present.
+    """
+    origin = get_origin(thing) or thing
+    args = {*get_args(thing)}
+
+    assert (
+        origin is not Optional
+    ), "Unreachable code / guard; Optionals are always Unions that include None."
+
+    if origin is dict:
+        # In this case, args isn't a collection of types; rather a (key_type, value_type).
+        # Dict[str, Any] would therefore come out as a (Dict, Union[str, Any]) which is wrong.
+        # since we don't do anything special for dicts anyway yet, drop the arg types and carry on.
+        return dict, ()
+
+    # Remove NoneType if it's present. If the value is given as None, we return None, no questions asked,
+    # so we really don't need to keep this information.
+    args.discard(type(None))
+
+    if len(args) < 2:
+        return origin, tuple(args)
+
+    if len(args) == 2:
+        return origin, _as_union_of_thing_or_list_of_things(*args)
+
+    # Unions of various PASSTHROUGH_TYPES are allowed (we expect them to be converted already e.g. json.load)
+    if not args.difference(PASSTHROUGH_TYPES):
+        return origin, tuple(args)
+
+    raise UnsupportedAnnotation(thing)
+
+
+def _as_union_of_thing_or_list_of_things(*annotation: Type) -> Tuple[Type, Type]:
+    """
+    Validates that the annotation accepts thing or a list of things.
+    Returns the ordered args; we always move the target type to the first thing in the tuple.
+    """
+    if len(annotation) == 2:
+        target_type: Optional[Any] = None
+        container_kind: Optional[Any] = None
+
+        for hint in annotation:
+            origin = get_origin(hint)
+            if origin is None:
+                target_type = hint
+            else:
+                container_kind = origin
+
+        if container_kind is list and target_type is not None:
+            # note: ignore is required because mypy thinks this should be part of the static analysis.
+            # I suppose we should create our own wrappers instead of piggy-backing on typing constructs at runtime.
+            return target_type, List[target_type]  # type: ignore[valid-type]
+
+    raise UnsupportedAnnotation(annotation)
+
+
+def deserialize(value: Any, *, hint: Any = None) -> Any:
+    origin, args = _resolve_hint(hint)
+
+    if origin in PASSTHROUGH_TYPES or value is None:
+        return value
+
+    if origin is Union:
+        # Unions of PASSTHROUGH_TYPES types are allowed and assumed to be in the proper type already
+        if not {*args}.difference(PASSTHROUGH_TYPES):
+            return value
+
+        if len(args) == 1:
+            return deserialize(value, hint=args[0])
+
+        if len(args) == 2:
+            if isinstance(value, list):
+                return deserialize(value, hint=List[args[0]])  # type: ignore[valid-type]
+            else:
+                return deserialize(value, hint=args[0])
+
+    if origin is list:
+        args = args or cast(Tuple[Type, ...], (Any,))
+        return _deserialize(value, hint=list, contains=args[0])
+
+    if inspect.isclass(origin) and isinstance(value, origin):
+        # it's a custom class and it's already converted
+        return value
+
+    # annotation arguments are not supported past this point, so we can omit them.
+    return _deserialize(value, hint=origin)
+
+
+@dispatch(switch_pos="hint")
+def _deserialize(value: Any, *, hint: Any, contains: Optional[Type] = None) -> Any:
+    if inspect.isclass(hint) and isinstance(value, dict):
+        return flex(hint)(**value)
+
+    # todo: raise?
+    return value
+
+
+@_deserialize.register(list)
+def _deserialize_list(value: Any, *, hint: list, contains: Optional[Type] = None) -> List:
+    if isinstance(value, list):
+        return [deserialize(item, hint=contains) for item in value]
+
+    # todo: raise?
+    return value  # type: ignore[no-any-return]
+
+
+# @_deserialize.register(dict)
+# def _deserialize_dict(value: Dict[str, Any], *, hint: Type[dict]) -> Dict[str, Any]:
+#     if isinstance(hint, GenericMeta):
+#         # py3.6 path
+#         # noinspection PyUnresolvedReferences
+#         item_type = hint.__args__[1] if hint.__args__ else None
+#         try:
+#             return {key: deserialize(value, hint=item_type) for key, value in value.items()}
+#         except AttributeError:
+#             print("!")
+#
+#     # noinspection PyArgumentList
+#     return hint((k, deserialize(v)) for k, v in value.items())
+
+
+# @_deserialize.register(list)
+# def _deserialize_list(value: List[Any], *, hint: Type[list]) -> List:
+#     if isinstance(value, str):
+#         raise ValueError
+#
+#     if isinstance(hint, GenericMeta):
+#         # py3.6 path
+#         # noinspection PyUnresolvedReferences
+#         item_type = hint.__args__[0] if hint.__args__ else None
+#         return [deserialize(v, hint=item_type) for v in value]
+#
+#     # noinspection PyArgumentList
+#     return hint(deserialize(v) for v in value)
+#
+#
+# @_deserialize.register(JidType)
+# def _deserialize_jid_type(value: Dict[str, Any], *, hint: Type[JidType]) -> JidType:
+#     """Most cases should be handled by the shortcircuit in _deserialize; this one handles cases where the
+#     service returns a correctly formatted object without a _type hint."""
+#     if isinstance(value, JidType):
+#         return value
+#
+#     if hint is JidType or not issubclass(hint, JidType):
+#         raise TypeError(f'Unable to infer JidType: {value}')
+#
+#     return flexcase(hint)(**{k: v for k, v in value.items() if v is not None})
+#
+#
+# @_deserialize.register(FunctionType)
+# @_deserialize.register(MethodType)
+# def _deserialize_from_callable(value: Dict[str, Any], *, hint: Callable) -> Dict[str, Any]:
+#     """Use annotations from fn to deserialize value. Extra args will be stripped out and casing is flexible."""
+#     assert isinstance(value, dict)
+#     value = unflex(hint, value)  # fix the case of keys in value
+#     for argument_name, annotation in find_annotations(hint).items():
+#         if argument_name == 'return':
+#             continue
+#         # set the deserialized value
+#         value[argument_name] = deserialize(value[argument_name], hint=annotation)
+#     return value
+#
+#
+# @_deserialize.register(datetime)
+# def _deserialize_datetime(value: float, *, hint: Type[datetime]) -> datetime:
+#     if isinstance(value, datetime):
+#         return value
+#     return hint.utcfromtimestamp(value)
+#
+#
+# # @__deserialize.register(StringEnum)
+# @_deserialize.register(JidEnumFlag)
+# def _deserialize_enum(value: str, *, hint: Type[JidEnumFlag]) -> JidEnumFlag:
+#     if isinstance(value, JidEnumFlag):
+#         return value
+#
+#     if isinstance(value, list) and len(value) == 1:
+#         # in SOAP, these are contained within a list.
+#         value = value[0]
+#
+#     if isinstance(value, int):
+#         # noinspection PyArgumentList
+#         return hint(value)
+#
+#     value = value.replace('None', 'None_')
+#
+#     if '+' in value:
+#         # noinspection PyArgumentList
+#         return functools.reduce(
+#             lambda x, y: x | y,
+#             (hint[flag] for flag in value.split('+')))
+#
+#     # noinspection PyArgumentList
+#     try:
+#         return hint[value]
+#     except KeyError as ex:
+#         if value.isnumeric():
+#             # noinspection PyArgumentList
+#             return hint(int(value))
+#         raise ex
+
+
+def _deserialize_normalized(
+    value: Any, outer_type: Type[T], inner_type: Optional[Type] = None
+) -> T:
+    ...

--- a/coveo-functools/poetry.lock
+++ b/coveo-functools/poetry.lock
@@ -87,6 +87,19 @@ type = "directory"
 url = "../coveo-testing"
 
 [[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
 name = "inflection"
 version = "0.5.1"
 description = "A port of Ruby on Rails inflector to Python"
@@ -98,6 +111,14 @@ python-versions = ">=3.5"
 name = "iniconfig"
 version = "1.1.1"
 description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -129,11 +150,11 @@ python-versions = "*"
 
 [[package]]
 name = "packaging"
-version = "20.9"
+version = "21.0"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -161,6 +182,22 @@ dev = ["pre-commit", "tox"]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -221,7 +258,7 @@ python-versions = "*"
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "32c7e4035863c3ee30fd5dcd8238a5a325badefd7d1b21d5340ba3a8cc4eda52"
+content-hash = "6373c73945d59c781f5e9000a604eb4abaea54433152b817e416655fd2792108"
 
 [metadata.files]
 appdirs = [
@@ -249,6 +286,10 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coveo-testing = []
+flake8 = [
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
+]
 inflection = [
     {file = "inflection-0.5.1-py2.py3-none-any.whl", hash = "sha256:f38b2b640938a4f35ade69ac3d053042959b62a0f1076a5bbaa1b9526605a8a2"},
     {file = "inflection-0.5.1.tar.gz", hash = "sha256:1a29730d366e996aaacffb2f1f1cb9593dc38e2ddd30c91250c6dde09ea9b417"},
@@ -256,6 +297,10 @@ inflection = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+mccabe = [
+    {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
+    {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 mypy = [
     {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
@@ -287,8 +332,8 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
 packaging = [
-    {file = "packaging-20.9-py2.py3-none-any.whl", hash = "sha256:67714da7f7bc052e064859c05c595155bd1ee9f69f76557e21f051443c20947a"},
-    {file = "packaging-20.9.tar.gz", hash = "sha256:5b327ac1320dc863dca72f4514ecc086f31186744b84a230374cc1fd776feae5"},
+    {file = "packaging-21.0-py3-none-any.whl", hash = "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"},
+    {file = "packaging-21.0.tar.gz", hash = "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7"},
 ]
 pathspec = [
     {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
@@ -301,6 +346,14 @@ pluggy = [
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
     {file = "py-1.10.0.tar.gz", hash = "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3"},
+]
+pycodestyle = [
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
+]
+pyflakes = [
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},

--- a/coveo-functools/pyproject.toml
+++ b/coveo-functools/pyproject.toml
@@ -18,6 +18,7 @@ typing_extensions = "*"
 attrs = "*"
 black = { version = "21.6b0", allow-prereleases = true }
 coveo-testing = { path = "../coveo-testing/", develop = true }
+flake8 = "*"
 mypy = "0.910"
 
 
@@ -25,6 +26,9 @@ mypy = "0.910"
 pytest = true
 offline-build = true
 black = true
+
+[tool.stew.ci.custom-runners]
+flake8 = { args = ["--ignore=E501,W503"]}
 
 
 [tool.black]

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -96,7 +96,7 @@ def test_flex_raise_not_set() -> None:
         missing: Optional[str]
 
     with pytest.raises(TypeError):
-        _ = flex(MockUnion)()  # type: ignore[call-arg]
+        _ = flex(MockUnion)()
 
 
 class TestInterface(Protocol):

--- a/coveo-functools/tests_functools/test_flex.py
+++ b/coveo-functools/tests_functools/test_flex.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from typing import Final, Dict, Any, Optional, Union, Callable, Generator, Type, Protocol
 
 import pytest
-from coveo_functools.exceptions import AmbiguousAnnotation
+from coveo_functools.exceptions import UnsupportedAnnotation
 from coveo_functools.flex import flex, RAW_KEY
 from coveo_testing.markers import UnitTest
 from coveo_testing.parametrize import parametrize
@@ -20,7 +20,7 @@ EXPECTED_INNER: Final[MockInner] = MockInner(EXPECTED_VALUE)
 
 
 def _flex_mocks() -> Generator[Any, None, None]:
-    """General set of mocks meant to be called with PAYLOAD."""
+    """General set of mocks meant to be called with DEFAULT_PAYLOAD."""
 
     @flex
     class MockClass:
@@ -74,7 +74,7 @@ def test_flex_invalid_union() -> None:
     class MockUnion:
         union: Union[str, object]
 
-    with pytest.raises(AmbiguousAnnotation):
+    with pytest.raises(UnsupportedAnnotation):
         _ = flex(MockUnion)(**{"union": "sorry"})
 
 

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -1,0 +1,108 @@
+from dataclasses import dataclass
+
+import pytest
+from coveo_functools.exceptions import UnsupportedAnnotation
+from typing import Final, List, Any, Optional, Union, Dict, Type
+
+from coveo_testing.parametrize import parametrize
+
+from coveo_functools.flex import deserialize, JSON_TYPES
+
+
+@dataclass
+class MockType:
+    value: str
+
+
+DEFAULT_VALUE: Final[str] = "yup"
+DEFAULT_PAYLOAD = {"value": DEFAULT_VALUE}
+DEFAULT_MOCK: Final[MockType] = MockType(DEFAULT_VALUE)
+
+
+@parametrize(
+    ("hint", "payload", "expected"),
+    (
+        (List[MockType], [DEFAULT_PAYLOAD], [DEFAULT_MOCK]),
+        (list, [DEFAULT_PAYLOAD], [DEFAULT_PAYLOAD]),
+        # Optional lists
+        (Optional[List[MockType]], [DEFAULT_PAYLOAD], [DEFAULT_MOCK]),
+        (
+            Optional[List[MockType]],
+            [DEFAULT_PAYLOAD, DEFAULT_PAYLOAD],
+            [DEFAULT_MOCK, DEFAULT_MOCK],
+        ),
+        (Optional[List[MockType]], [], []),
+        (Optional[List[MockType]], None, None),
+        # List of optional MockType
+        (List[Optional[MockType]], [DEFAULT_PAYLOAD], [DEFAULT_MOCK]),
+        (List[Optional[MockType]], [DEFAULT_PAYLOAD, None], [DEFAULT_MOCK, None]),
+        (List[Optional[MockType]], [None, DEFAULT_PAYLOAD], [None, DEFAULT_MOCK]),
+        (List[Optional[MockType]], [None], [None]),
+        (List[Optional[MockType]], [], []),
+        # Optional lists of optional mock types
+        (Optional[List[Optional[MockType]]], [None, DEFAULT_PAYLOAD], [None, DEFAULT_MOCK]),
+        (Optional[List[Optional[MockType]]], None, None),
+        # inception
+        (List[Optional[List[Optional[MockType]]]], [[DEFAULT_PAYLOAD]], [[DEFAULT_MOCK]]),
+        (
+            List[Optional[List[Optional[MockType]]]],
+            [None, [DEFAULT_PAYLOAD]],
+            [None, [DEFAULT_MOCK]],
+        ),
+        (List[Optional[List[Optional[MockType]]]], [[]], [[]]),
+        (List[Optional[List[Optional[MockType]]]], [], []),
+    ),
+)
+def test_deserialize_to_list(hint: Any, payload: Any, expected: Any) -> None:
+    assert deserialize(payload, hint=hint) == expected
+
+
+def test_deserialize_unions_passthrough() -> None:
+    """Anything from the json types will be given back without checking; this allows unions of base types."""
+    union = Union[JSON_TYPES]  # type: ignore[valid-type]
+
+    assert deserialize(DEFAULT_VALUE, hint=union) == DEFAULT_VALUE
+
+
+def test_deserialize_unions_limited() -> None:
+    """
+    When it's not 100% builtin types, flex limits to a single type within unions.
+    This may change in the future.
+    """
+    with pytest.raises(UnsupportedAnnotation):
+        assert deserialize(DEFAULT_VALUE, hint=Union[str, MockType]) == DEFAULT_VALUE
+
+
+@parametrize("hint", (Union[MockType, List[MockType]], Union[List[MockType], MockType]))
+@parametrize(
+    ("payload", "expected"),
+    (
+        (DEFAULT_PAYLOAD, DEFAULT_MOCK),
+        ([DEFAULT_PAYLOAD], [DEFAULT_MOCK]),
+        (None, None),
+        ([], []),
+    ),
+)
+def test_deserialize_thing_or_list_of_things(hint: Type, payload: Any, expected: Any) -> None:
+    """
+    Some APIs will return a single map if there's one object, else a list of them.
+    Such objects must be annotated with Union[Thing, List[Thing]].
+    """
+    assert deserialize(payload, hint=hint) == expected
+
+
+@parametrize(
+    "hint",
+    (
+        Dict[str, Any],
+        Dict[int, bool],
+        Dict,
+        Dict[Any, Any],
+        Dict[Union[str, bool], Any],
+        Dict[Any, Union[bytes, MockType]],
+        Dict[Optional[Union[str, int]], Optional[Union[str, MockType, Optional[bool]]]],
+    ),
+)
+def test_deserialize_dict(hint: Type) -> None:
+    """We don't do much with'em, but they gotta work!"""
+    assert deserialize(DEFAULT_PAYLOAD, hint=hint) == DEFAULT_PAYLOAD

--- a/coveo-functools/tests_functools/test_wait.py
+++ b/coveo-functools/tests_functools/test_wait.py
@@ -1,7 +1,7 @@
 """ Tests the wait method features """
 
 import datetime
-from typing import Dict, List, Type, Tuple, TypedDict
+from typing import List, Type, Tuple, TypedDict
 
 from coveo_testing.markers import UnitTest
 from coveo_testing.parametrize import parametrize


### PR DESCRIPTION
## NOTE: IF YOU DIDN'T REVIEW THIS YET, JUST GO AND REVIEW #78 INSTEAD.

So, turns out python's dispatcher will not let me dispatch on types like List, Union, Optional, etc. Eventually I may implement it, but for now, it's going to be a very cheap dispatch deserializer.

At least it's still a lot cleaner than the previous PR.