### PR TITLE
flex // improved documentation

### DIFF
--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -1,18 +1,18 @@
-# coveo-functools
+# `coveo-functools`
 
 Introspection, finalizers, delegates, dispatchers, waiters...
 These utilities aim at increasing productivity!
 
 
-# annotations
+# `annotations`
 
 Introspect classes and callables at runtime.
 
 Can convert string annotations into their actual type reference.
 
 
-# flex
-## overview
+# `flex`
+## Overview
 Flex works with annotations to adjust and convert input data to match your target structure.
 
 It was originally done as a mean to fit `CamelCase` payloads from external APIs into `snake_case` classes.
@@ -110,7 +110,7 @@ Flex can be used with:
 These are subject to change.
 
 
-## flex.deserialize
+## `flex.deserialize`
 
 This is where the magic happens, and is the recommended usage whenever it meets your use case. 
 
@@ -135,11 +135,9 @@ Here's an example puzzle! An uncanny API returns a messy "transaction" JSON:
 }
 ```
 
-
 Wouldn't it be convenient if you could create simple classes/dataclasses around them without any boilerplate?
 
-
-There are many  But you can solve it with flex. In one line, too!
+You can solve it with flex. In one line, too!
 
 Start by designing a hierarchy of classes with annotations that closely follow the API reference.
 
@@ -180,9 +178,6 @@ Did you notice any flex-related boilerplate in the snippet above? No? Good! :)
 
 Here's how you can use the flex deserializer to bend the furious API response into your perfect python classes:
 
-
-
-
 ```python
 payload = {
     "Sold_To": {"Name": "Jon"},
@@ -199,19 +194,19 @@ payload = {
     "Id": "GgfhAs89876yh.z"
 }
 
-one_transaction = flex.deserialize(payload, hint=Transaction)
-list_transactions = flex.deserialize([payload, payload], hint=List[Transaction])
+transaction = flex.deserialize(payload, hint=Transaction)
+all_transactions = flex.deserialize(payload, hint=List[Transaction])
 ```
 
 Interesting details:
 - Well, the casing worked! :shrug:
 - `Id` and `NOTE` were dropped because they were excluded from the `Transaction` model. Time saver; some APIs return _tons_ of data.
 - The rebates actually kept the keys, and created `Rebate` instances as the values.
-- In some cases, rebates is a `Rebate` instance, sometimes it's a `List[Rebate]`; it follows whatever the API returns because it was annotated as such.
-- In the `get_all_transactions` call, `List[Annotation]` was used directly as the hint. Nifty!
+- The value type of the `rebates` dict is either a single `Rebate` instance or a list of them. See the "thing or list of things" section below for considerations.
+- In the `all_transactions` variable, `List[Annotation]` was used directly as the hint. Nifty!
 
 
-## @flex and flex(obj)
+## `@flex` and `flex(obj)`
 
 There is a decorator version of `deserialize`.
 
@@ -312,7 +307,7 @@ class ApiWrapper:
 ```
 
 
-## consideration vs mypy
+## Consideration for mypy
 
 There is one annotation case worth mentioning. 
 Consider this code:
@@ -339,7 +334,7 @@ payload: Dict[str, Any] = {"inner": {}}
 _ = fn(**payload)
 ```
 
-# unflex
+# `unflex`
 
 Unflex is one of the utilities used by `flex.deserializer`.
 
@@ -361,7 +356,7 @@ assert unflex(fn, {"ARG1": ..., "ArG_2": ..., "extra": ...}) == {"arg1": ..., "a
 Note: To target classes, you need to `unflex(cls.__init__, ...)`
 
 
-## @flexcase
+## `@flexcase`
 
 `flexcase` is the decorator version of `unflex`:
 
@@ -378,7 +373,7 @@ assert fn(ARG1="hello", _arg2="world", extra=...) == "hello world"
 ```
 
 
-# dispatch
+# `dispatch`
 
 An enhanced version of [functools.singledispatch](https://docs.python.org/3.8/library/functools.html#functools.singledispatch):
 
@@ -388,7 +383,7 @@ An enhanced version of [functools.singledispatch](https://docs.python.org/3.8/li
 - You can target an argument by its name too, regardless of its position
 
 
-## finalizer
+## `finalizer`
 
 A classic and simple try/finally context manager that launches a delegate once a block of code has completed.
 
@@ -411,7 +406,7 @@ def test_spawning_containers() -> None:
 ```
 
 
-## wait.until()
+## `wait.until()`
 
 Waits for a condition to happen. Can be configured with exceptions to ignore.
 
@@ -426,7 +421,7 @@ wait.until(_ready, timeout_s=30, retry_ms=100, handle_exceptions=ConnectionError
            failure_message="The service failed to respond in time.")
 ```
 
-## wait.Backoff
+## `wait.Backoff`
 
 A customizable class to assist in the creation of backoff retry strategies.
 

--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -102,7 +102,8 @@ Flex can be used with:
 
 - Variable positional args (such as `def fn(*args): ...`) are left untouched.
 - Basic json-compatible types are left untouched. This is determined by the annotation, not the actual value.
-- If None is given as a value to deserialize into anything, None is given back. Absolutely no validation occurs in this case.
+- If `None` is given as a value to deserialize into anything, `None` is given back. Absolutely no validation occurs in this case.
+
 - You can only `Union` basic json-compatible types, or `List[T], T`
 - No support for additional `typing` and `collections` objects other than the ones mentioned in this documentation.
 
@@ -140,7 +141,8 @@ Wouldn't it be convenient if you could create simple classes/dataclasses around 
 
 There are many  But you can solve it with flex. In one line, too!
 
-Start by designing a hierarchy of classes with annotations that closely follows the API reference.
+Start by designing a hierarchy of classes with annotations that closely follow the API reference.
+
 Remember, casing and underscore are ignored in flex, so you could use pep8 if you want:
 
 ```python
@@ -176,7 +178,8 @@ class Transaction:
 
 Did you notice any flex-related boilerplate in the snippet above? No? Good! :)
 
-Here's how you can use flex's deserializer to bend the furious API's response into your perfect python classes:
+Here's how you can use the flex deserializer to bend the furious API response into your perfect python classes:
+
 
 
 
@@ -340,7 +343,8 @@ _ = fn(**payload)
 
 Unflex is one of the utilities used by `flex.deserializer`.
 
-It is responsible to adjust the keyword arguments of a dictionary, so they match the argument names of a target function.
+It is responsible for adjusting the keyword arguments of a dictionary, so that they match the argument names of a target function.
+
 
 It does not perform any conversion; all it does is matching keys.
 Extra keys are dropped by default:

--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -195,7 +195,7 @@ payload = {
 }
 
 transaction = flex.deserialize(payload, hint=Transaction)
-all_transactions = flex.deserialize(payload, hint=List[Transaction])
+all_transactions = flex.deserialize([payload, payload], hint=List[Transaction])
 ```
 
 Interesting details:

--- a/coveo-functools/coveo_functools/casing.py
+++ b/coveo-functools/coveo_functools/casing.py
@@ -1,6 +1,6 @@
 import functools
 import re
-from typing import Match, Iterable, Dict, Callable, Any, TypeVar, Mapping, Type
+from typing import Match, Iterable, Dict, Callable, Any, TypeVar, Mapping, Type, Final
 
 import inflection
 
@@ -53,6 +53,9 @@ def snake_case(string: str, bad_casing: Iterable[str] = ()) -> str:
     return result
 
 
+TRANSLATION_TABLE: Final = str.maketrans("", "", "_-. ")
+
+
 class _FlexcaseDecorator:
     """Allow passing kwargs to a method without consideration for casing or underscores."""
 
@@ -100,7 +103,7 @@ class _FlexcaseDecorator:
     @staticmethod
     def _lookup_key(key: str) -> str:
         """Return a normalized lookup key."""
-        return key.replace("-", "").replace("_", "").lower()
+        return key.translate(TRANSLATION_TABLE).lower()
 
 
 def flexcase(

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass
+from typing import Final, List, Any, Optional, Union, Dict, Type
 
 import pytest
 from coveo_functools.exceptions import UnsupportedAnnotation
-from typing import Final, List, Any, Optional, Union, Dict, Type
-
+from coveo_testing.markers import UnitTest
 from coveo_testing.parametrize import parametrize
 
 from coveo_functools.flex import deserialize, JSON_TYPES
@@ -22,6 +22,7 @@ DEFAULT_MAP_PAYLOAD = {"item1": DEFAULT_PAYLOAD, "item2": DEFAULT_PAYLOAD}
 DEFAULT_MAP_MOCK: Final[Dict[str, MockType]] = {"item1": DEFAULT_MOCK, "item2": DEFAULT_MOCK}
 
 
+@UnitTest
 @parametrize(
     ("hint", "payload", "expected"),
     (
@@ -60,6 +61,7 @@ def test_deserialize_to_list(hint: Any, payload: Any, expected: Any) -> None:
     assert deserialize(payload, hint=hint) == expected
 
 
+@UnitTest
 def test_deserialize_unions_passthrough() -> None:
     """Anything from the json types will be given back without checking; this allows unions of base types."""
     union = Union[JSON_TYPES]  # type: ignore[valid-type]
@@ -67,6 +69,7 @@ def test_deserialize_unions_passthrough() -> None:
     assert deserialize(DEFAULT_VALUE, hint=union) == DEFAULT_VALUE
 
 
+@UnitTest
 def test_deserialize_unions_limited() -> None:
     """
     When it's not 100% builtin types, flex limits to a single type within unions.
@@ -76,6 +79,7 @@ def test_deserialize_unions_limited() -> None:
         assert deserialize(DEFAULT_VALUE, hint=Union[str, MockType]) == DEFAULT_VALUE
 
 
+@UnitTest
 @parametrize("hint", (Union[MockType, List[MockType]], Union[List[MockType], MockType]))
 @parametrize(
     ("payload", "expected"),
@@ -95,6 +99,7 @@ def test_deserialize_thing_or_list_of_things(hint: Type, payload: Any, expected:
     assert deserialize(payload, hint=hint) == expected
 
 
+@UnitTest
 @parametrize(
     "hint",
     (
@@ -111,6 +116,7 @@ def test_deserialize_dict(hint: Type) -> None:
     assert deserialize(DEFAULT_PAYLOAD, hint=hint) == DEFAULT_PAYLOAD
 
 
+@UnitTest
 @parametrize(
     "hint",
     (
@@ -123,6 +129,7 @@ def test_deserialize_dict_with_custom_value_type(hint: Any) -> None:
     assert deserialize(DEFAULT_MAP_PAYLOAD, hint=hint) == DEFAULT_MAP_MOCK
 
 
+@UnitTest
 @parametrize(
     ("hint", "payload", "expected"),
     (
@@ -147,6 +154,7 @@ def test_deserialize_dict_complex(hint: Any, payload: Any, expected: Any) -> Non
     assert deserialize(payload, hint=hint) == expected
 
 
+@UnitTest
 def test_deserialize_dict_invalid_union() -> None:
     """Make sure the union rules are respected in the dict value annotation."""
     with pytest.raises(UnsupportedAnnotation):

--- a/coveo-functools/tests_functools/test_flexcase.py
+++ b/coveo-functools/tests_functools/test_flexcase.py
@@ -27,6 +27,7 @@ def _flexcase_test(mock_class: Callable) -> None:
     assert mock_class(ArG_1=1, Arg2=True)
     assert mock_class(_arG1=1, A___rg2_=True)
     assert mock_class(ar_g2=True, ARG_1=1)
+    assert mock_class(**{"A r_ g. 1": True, "__arg2": True})
 
 
 @UnitTest


### PR DESCRIPTION
I found the doc a little messy so I went ahead and tried to improve it. I suggest you don't use the diff for the `readme` file because it changed substantially.

also: 
- added spaces and dots to unflex
- added missing unit test decorators


