### PR TITLE
Support git references in stew build

### DIFF
--- a/coveo-stew/coveo_stew/offline_publish.py
+++ b/coveo-stew/coveo_stew/offline_publish.py
@@ -5,14 +5,12 @@ from typing import Set, Dict, cast, List, Optional, Tuple
 
 from coveo_styles.styles import echo
 from coveo_systools.subprocess import check_call, check_output
-from poetry.core.packages import (
-    Package,
-    Dependency,
-    DirectoryDependency,
-    FileDependency,
-    URLDependency,
-    VCSDependency,
-)
+from poetry.core.packages.dependency import Dependency
+from poetry.core.packages.directory_dependency import DirectoryDependency
+from poetry.core.packages.file_dependency import FileDependency
+from poetry.core.packages.package import Package
+from poetry.core.packages.url_dependency import URLDependency
+from poetry.core.packages.vcs_dependency import VCSDependency
 
 from coveo_stew.environment import PythonEnvironment, PythonTool
 from coveo_stew.exceptions import PythonProjectException

--- a/coveo-stew/pyproject.toml
+++ b/coveo-stew/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coveo-stew"
-version = "2.0.0"
+version = "2.1.0"
 description = "Opinionated python packaging and development utilities"
 license = "Apache-2.0"
 readme = "README.md"


### PR DESCRIPTION
So when you run stew build on a project with a git reference, it ends up calling `pip wheels <all-my-packages> --index-url <githuburl>` 😆 That did not go well.

This PR adds support for the VCS references, which may be git+ or hg+ prefixed.

We don't support the directory and file dependencies because no use case. At least now, we let the user know. It should be a really easy PR once someone has a use case. #famouslastwords

I didn't add tests because it was kinda deep in poetry's config. But I did some test runs on some of our private repos and it went well.