### PR TITLE
flex // raise if the hint cannot be instantiated

### DIFF
--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -7,4 +7,4 @@ class Flexception(CoveoFunctoolsException):  # sorry for the pun :socanadian:
 
 
 class UnsupportedAnnotation(Flexception, NotImplementedError):
-    """When an annotation isn't suported."""
+    """When an annotation isn't supported."""

--- a/coveo-functools/coveo_functools/flex.py
+++ b/coveo-functools/coveo_functools/flex.py
@@ -4,6 +4,7 @@ import collections
 import functools
 import inspect
 from enum import Enum
+from inspect import isabstract
 from typing import (
     Type,
     TypeVar,
@@ -141,6 +142,9 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]]) -> T:
     - If hint is a custom class, the value must be a dictionary to "flex" into the class.
     - Hint may be a `Union[T, List[T]]`, in which case the value must be a dict or a list of them.
     """
+    if isabstract(hint):
+        raise UnsupportedAnnotation(f"{hint} is abstract and cannot be instantiated.")
+
     if value is None:
         return None  # nope!
 

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -1,3 +1,4 @@
+from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
 from typing import Final, List, Any, Optional, Union, Dict, Type
@@ -241,3 +242,13 @@ def test_deserialize_static_typing() -> None:
 
         # mypy sees that fn returns a str, not an int
         _ = deserialize(fn, hint=fn)(value="") / 2  # type: ignore[operator]
+
+
+def test_flex_raise_on_abstract() -> None:
+    class Abstract(metaclass=ABCMeta):
+        @abstractmethod
+        def api(self) -> None:
+            ...
+
+    with pytest.raises(UnsupportedAnnotation):
+        deserialize({}, hint=Abstract)


### PR DESCRIPTION
Raise a proper exception message if we are to instantiate an abstract class.

Without this, the error ends up being very cryptic:

```
AttributeError: 'wrapper_descriptor' object has no attribute '__module__'
```