### PR TITLE
flex // accept callables as hints

### DIFF
--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -135,8 +135,8 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]]) -> T:
 
 @dispatch(switch_pos="hint")
 def _deserialize(value: Any, *, hint: TypeHint, contains: Optional[TypeHint] = None) -> Any:
-    """Fallback deserialization; if value is dict and hint is class, flex it. Else just return value."""
-    if inspect.isclass(hint) and isinstance(value, dict):
+    """Fallback deserialization; if value is dict and hint is callable, flex it. Else just return value."""
+    if callable(hint) and isinstance(value, dict):
         return hint(**convert_kwargs_for_unpacking(value, hint=hint))
 
     return value

--- a/coveo-functools/tests_functools/test_flex_adapters.py
+++ b/coveo-functools/tests_functools/test_flex_adapters.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from typing import Type, Any, Generator, List, Dict, Optional
@@ -130,3 +132,25 @@ def test_deserialize_mutate_value_adapter() -> None:
     assert "test" in payload
     assert isinstance(instance.test, Implementation)
     assert instance.test.value == "success"
+
+
+@dataclass
+class TestFactory:
+    value: str
+
+    @classmethod
+    def factory(cls, raw: Dict[str, str]) -> TestFactory:
+        return deserialize(raw, hint=TestFactory)
+
+
+@parametrize('raw', (True, False))
+def test_deserialize_adapter_factory(raw: bool) -> None:
+    """The adapter may return a callable."""
+
+    def factory_adapter(value: Any) -> TypeHint:
+        return TestFactory.factory if 'raw' in value else TestFactory
+
+    register_subclass_adapter(TestFactory, factory_adapter)
+
+    payload = {'raw': {"value": "success"}} if raw else {"value": "success"}
+    assert deserialize(payload, hint=TestFactory).value == 'success'

--- a/coveo-functools/tests_functools/test_flex_adapters.py
+++ b/coveo-functools/tests_functools/test_flex_adapters.py
@@ -152,5 +152,5 @@ def test_deserialize_adapter_factory(raw: bool) -> None:
 
     register_subclass_adapter(TestFactory, factory_adapter)
 
-    payload = {'raw': {"value": "success"}} if raw else {"value": "success"}
+    payload: Dict[str, Any] = {'raw': {"value": "success"}} if raw else {"value": "success"}
     assert deserialize(payload, hint=TestFactory).value == 'success'

--- a/coveo-functools/tests_functools/test_flex_adapters.py
+++ b/coveo-functools/tests_functools/test_flex_adapters.py
@@ -143,14 +143,13 @@ class TestFactory:
         return deserialize(raw, hint=TestFactory)
 
 
-@parametrize('raw', (True, False))
-def test_deserialize_adapter_factory(raw: bool) -> None:
+def test_deserialize_adapter_factory_classmethod() -> None:
     """The adapter may return a callable."""
 
     def factory_adapter(value: Any) -> TypeHint:
-        return TestFactory.factory if 'raw' in value else TestFactory
+        return TestFactory.factory if "raw" in value else TestFactory
 
     register_subclass_adapter(TestFactory, factory_adapter)
 
-    payload: Dict[str, Any] = {'raw': {"value": "success"}} if raw else {"value": "success"}
-    assert deserialize(payload, hint=TestFactory).value == 'success'
+    payload: Dict[str, Any] = {"raw": {"value": "success"}}
+    assert deserialize(payload, hint=TestFactory).value == "success"


### PR DESCRIPTION
This was a bit of an oversight; the underlying flex machinery is able to use any callable, not just classes. This is a key feature if we want to accept factories through the subclass adapter.