### PR TITLE
Fix `filter_ansi`

### DIFF
--- a/coveo-systools/coveo_systools/streams.py
+++ b/coveo-systools/coveo_systools/streams.py
@@ -3,23 +3,24 @@ import re
 # 7-bit and 8-bit C1 ANSI sequences  (note: this is a bytes regex, not str)
 # We use this to filter out ANSI codes from console outputs
 # Source: https://stackoverflow.com/a/14693789/1741414
-ANSI_ESCAPE_8BIT = re.compile(
+
+# Update: Originally we used the regex with the 8-bit codes, but a pip upgrade
+# introduced the character ━ (\xe2\x94\x81) to the stream. The `\xe2` was removed
+# by one of the 8bit regex sequences.
+
+# Since the goal is to remove colors and control codes, the simpler regex works just as well.
+
+ANSI_ESCAPE = re.compile(
     br"""
-    (?: # either 7-bit C1, two bytes, ESC Fe (omitting CSI)
-        \x1B
-        [@-Z\\-_]
-    |   # or a single 8-bit byte Fe (omitting CSI)
-        [\x80-\x9A\x9C-\x9F]
-    |   # or CSI + control codes
-        (?: # 7-bit CSI, ESC [ 
-            \x1B\[
-        |   # 8-bit CSI, 9B
-            \x9B
+        \x1B  # ESC
+        (?:   # 7-bit C1 Fe (except CSI)
+            [@-Z\\-_]
+        |     # or [ for CSI, followed by a control sequence
+            \[
+            [0-?]*  # Parameter bytes
+            [ -/]*  # Intermediate bytes
+            [@-~]   # Final byte
         )
-        [0-?]*  # Parameter bytes
-        [ -/]*  # Intermediate bytes
-        [@-~]   # Final byte
-    )
 """,
     re.VERBOSE,
 )
@@ -27,4 +28,4 @@ ANSI_ESCAPE_8BIT = re.compile(
 
 def filter_ansi(stream: bytes) -> bytes:
     """Removes ANSI sequences from a stream."""
-    return bytes(ANSI_ESCAPE_8BIT.sub(b"", stream))
+    return bytes(ANSI_ESCAPE.sub(b"", stream))

--- a/coveo-systools/coveo_systools/subprocess.py
+++ b/coveo-systools/coveo_systools/subprocess.py
@@ -238,7 +238,11 @@ def check_run(
             encoding = ("utf-8",)  # py3 strings are always utf-8
             output = output.encode(*encoding)
         assert isinstance(output, bytes)  # mypy
-        return filter_ansi(output).decode(*encoding).strip()
+        try:
+            return filter_ansi(output).decode(*encoding).strip()
+        except UnicodeDecodeError:
+            log.warning("An error occurred decoding the output stream; retrying in safe mode.")
+            return output.decode(errors="ignore").strip()
 
     return None
 

--- a/coveo-systools/tests_systools/test_streams.py
+++ b/coveo-systools/tests_systools/test_streams.py
@@ -2,12 +2,12 @@ from coveo_systools.streams import filter_ansi
 
 
 def test_conflicting_character() -> None:
-    """ Legacy bug; this sequence was introduced in a pip upgrade (a progress bar!) and broke the decoder. """
+    """Legacy bug; this sequence was introduced in a pip upgrade (a progress bar!) and broke the decoder."""
     content = b"\xe2\x94\x81"
     assert filter_ansi(content) == content
 
 
 def test_filter_ansi() -> None:
-    """ Strip out ansi codes from sequence. """
+    """Strip out ansi codes from sequence."""
     colors = b"\x1b[33mhello\x1b[0m"
     assert filter_ansi(colors) == b"hello"

--- a/coveo-systools/tests_systools/test_streams.py
+++ b/coveo-systools/tests_systools/test_streams.py
@@ -1,0 +1,14 @@
+from coveo_systools.streams import filter_ansi
+
+
+def test_conflicting_character() -> None:
+    """ Legacy bug; this sequence was introduced in a pip upgrade (a progress bar!) and broke the decoder. """
+    content = b"\xe2\x94\x81"
+    assert content.decode()
+    filter_ansi(content).decode()
+
+
+def test_filter_ansi() -> None:
+    """ Strip out ansi codes from sequence. """
+    colors = b"\x1b[33mhello\x1b[0m"
+    assert filter_ansi(colors) == b"hello"

--- a/coveo-systools/tests_systools/test_streams.py
+++ b/coveo-systools/tests_systools/test_streams.py
@@ -4,8 +4,7 @@ from coveo_systools.streams import filter_ansi
 def test_conflicting_character() -> None:
     """ Legacy bug; this sequence was introduced in a pip upgrade (a progress bar!) and broke the decoder. """
     content = b"\xe2\x94\x81"
-    assert content.decode()
-    filter_ansi(content).decode()
+    assert filter_ansi(content) == content
 
 
 def test_filter_ansi() -> None:


### PR DESCRIPTION
ref: https://stackoverflow.com/a/14693789/1741414

Originally we used the regex with the 8-bit codes, but a pip upgrade introduced the character ━ (\xe2\x94\x81) to the stream. The `\xe2` was removed by one of the 8-bit regex sequences, _as pointed out by master Pieters_.

Since the goal is to remove colors and control codes, the simpler regex works just as well.

Also added a failsafe.