### PR TITLE
support subclassing builtins

### DIFF
--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -143,6 +143,21 @@ def _deserialize(value: Any, *, hint: TypeHint, contains: Optional[TypeHint] = N
     return value
 
 
+@_deserialize.register(str)
+@_deserialize.register(int)
+@_deserialize.register(bytes)
+@_deserialize.register(float)
+def _deserialize_immutable(
+    value: Any,
+    *,
+    hint: Union[Type[str], Type[int], Type[bytes], Type[float]],
+    contains: Optional[TypeHint] = None,
+) -> Union[str, int, bytes, float]:
+    """If the hint is type that subclasses an immutable builtin, convert it."""
+    # note: the actual builtins are skipped early and won't call this method. See `is_passthrough_type`.
+    return hint(value)
+
+
 @_deserialize.register(list)
 def _deserialize_list(value: Any, *, hint: Type[list], contains: Optional[TypeHint] = None) -> List:
     """List deserialization into list of things."""

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -153,7 +153,7 @@ def _deserialize_immutable(
     hint: Union[Type[str], Type[int], Type[bytes], Type[float]],
     contains: Optional[TypeHint] = None,
 ) -> Union[str, int, bytes, float]:
-    """If the hint is type that subclasses an immutable builtin, convert it."""
+    """If the hint is a type that subclasses an immutable builtin, convert it."""
     # note: the actual builtins are skipped early and won't call this method. See `is_passthrough_type`.
     return hint(value)
 

--- a/coveo-functools/coveo_functools/flex/types.py
+++ b/coveo-functools/coveo_functools/flex/types.py
@@ -4,7 +4,6 @@ from typing import Any
 
 
 JSON_TYPES = (
-    bytes,  # technically not a json type, but maximizes compatibility
     str,
     bool,
     int,
@@ -13,7 +12,7 @@ JSON_TYPES = (
     dict,
 )  # list omitted to support list of custom types
 
-PASSTHROUGH_TYPES = {None, Any, *JSON_TYPES}
+PASSTHROUGH_TYPES = {None, Any, bytes, *JSON_TYPES}
 
 TypeHint = Any  # :shrug:
 

--- a/coveo-functools/coveo_functools/flex/types.py
+++ b/coveo-functools/coveo_functools/flex/types.py
@@ -4,6 +4,7 @@ from typing import Any
 
 
 JSON_TYPES = (
+    bytes,  # technically not a json type, but maximizes compatibility
     str,
     bool,
     int,

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -211,6 +211,19 @@ def test_deserialize_enum_alias() -> None:
     assert SomeEnum.Job is SomeEnum.Task  # it's the same picture.
 
 
+@parametrize("immutable_type", (str, int, bytes, float))
+def test_deserialize_immutable(immutable_type: Type) -> None:
+    class SubclassImmutable(immutable_type):  # type: ignore[valid-type,misc]
+        @property
+        def builtin_type(self) -> Type:
+            return immutable_type
+
+    value = deserialize(1, hint=SubclassImmutable)
+    assert isinstance(value, immutable_type)
+    assert isinstance(value, SubclassImmutable)
+    assert value.builtin_type is immutable_type
+
+
 def test_deserialize_static_typing() -> None:
     """
     This is actually a static typing test to ensure that `deserialize` correctly handles the generic annotations.


### PR DESCRIPTION
Flex used to bypass these.

The intended behavior for builtins is to skip them completely. This is handled by [this line](https://github.com/coveooss/coveo-python-oss/blob/23eacc4513a68e1fd187f5bfb1849bfcc6b3b232/coveo-functools/coveo_functools/flex/deserializer.py#L125). The rationale is that we are fed `json.load` material, where str, int, floats and bools are already in the correct type.

Now imagine a `class Subclass(str)` and a value of `patate`.  The `origin` becomes Subclass and not str. So the above line is false and we end up calling the deserialization.

The old behavior would end [here](https://github.com/coveooss/coveo-python-oss/blob/23eacc4513a68e1fd187f5bfb1849bfcc6b3b232/coveo-functools/coveo_functools/flex/deserializer.py#L140). Since value is not a dict, it would return the value as-is.

The new behavior will dispatch builtins (and subclasses of) into [this new function](https://github.com/coveooss/coveo-python-oss/blob/366a9f5fc1511f36d37aab7863c450da8b260acf/coveo-functools/coveo_functools/flex/deserializer.py#L150) and return an instance of the custom subclass.