### PR TITLE
coveo-testing // new helper to resolve mocks

### DIFF
--- a/coveo-testing/README.md
+++ b/coveo-testing/README.md
@@ -198,11 +198,11 @@ import pytest
 
 
 class StrMe:
-  def __init__(self, var: Any) -> None:
-    self.var = var
+    def __init__(self, var: Any) -> None:
+      self.var = var
       
-  def __str__(self) -> str:
-    return f"Value: {self.var}"
+    def __str__(self) -> str:
+      return f"Value: {self.var}"
 
 
 @parametrize('var', [['list', 'display'], [StrMe('hello')]])
@@ -221,3 +221,444 @@ If you run `pytest --collect-only` you will obtain the following:
     <Function test_param_from_pytest[var0]>
     <Function test_param_from_pytest[var1]>
 ```
+
+
+# Refactorable mock targets
+
+## Demo
+
+Consider this common piece of code:
+
+```python
+from unittest.mock import patch, MagicMock
+
+@patch("mymodule.clients.APIClient._do_request")
+def test(api_client_mock: MagicMock) -> None:
+    ...
+```
+
+Because the mock target is a string, it makes it difficult to move things around without breaking the tests. You need a
+tool that can extract the string representation of a python objet. This is what `ref` was built for:
+
+```python
+from unittest.mock import patch, MagicMock
+from coveo_testing.mocks import ref
+from mymodule.clients import APIClient
+
+@patch(*ref(APIClient._do_request))
+def test(api_client_mock: MagicMock) -> None:
+    ...
+```
+
+🚀 This way, you can rename or move `mymodule`, `clients`, `APIClient` or even `_do_request`, and your IDE should find
+these and adjust them just like any other reference in your project.
+
+Let's examine a more complex example:
+
+```python
+from unittest.mock import patch, MagicMock
+from mymodule.tasks import process
+
+@patch("mymodule.tasks.get_api_client")
+def test(get_api_client_mock: MagicMock) -> None:
+    assert process() is None  # pretend this tests the process function
+```
+
+The interesting thing in this example is that we're mocking `get_api_client` in the `tasks` module. 
+Let's take a look at the `tasks` module:
+
+```python
+from typing import Optional
+from mymodule.clients import get_api_client
+
+def process() -> Optional[bool]:
+    client = get_api_client()
+    return ...
+```
+
+As we can see, `get_api_client` is defined in another module.
+The test needs to patch the function _in the tasks module_ since that's the context it will be called from. 
+Unfortunately, inspecting `get_api_client` from the `tasks` module at runtime leads us back to `mymodule.clients`.
+
+This single complexity means that hardcoding the context `mymodule.tasks` and symbol `get_api_client` into a string
+for the patch is the straightforward solution.
+
+But with `ref`, you specify the context separately:
+
+```python
+from unittest.mock import patch, MagicMock
+from coveo_testing.mocks import ref
+from mymodule.clients import get_api_client
+from mymodule.tasks import process
+
+
+@patch(*ref(get_api_client, context=process))
+def test(get_api_client_mock: MagicMock) -> None:
+    assert process() is None  # pretend this tests the process function
+```
+
+🚀 By giving a context to `ref`, the symbol `get_api_client` will be resolved from the context of `process`, which is the
+`mymodule.tasks` module. The result is `mymodule.tasks.get_api_client`.
+
+If either objects (`get_api_client` or `process`) are moved or renamed using a refactoring tool, the mock will still
+point to the correct name and context.
+
+🚀 And a nice bonus is that your IDE can jump to `get_api_client`'s definition from the test file now!
+
+It should be noted that this isn't just some string manipulation. `ref` will import and inspect modules and objects
+to make sure that they're correct. Here's a more complex case with a renamed symbol:
+
+The module:
+
+```python
+from typing import Optional
+from mymodule.clients import get_api_client as client_factory  # it got renamed! 😱
+
+def process() -> Optional[bool]:
+    client = client_factory()
+    return ...
+```
+
+The test:
+
+```python
+from unittest.mock import patch, MagicMock
+from coveo_testing.mocks import ref
+from mymodule.clients import get_api_client
+from mymodule.tasks import process
+
+
+@patch(*ref(get_api_client, context=process))
+def test(get_api_client_mock: MagicMock) -> None:
+    assert process() is None  # pretend this tests the process function
+```
+
+Notice how the test and patch did not change despite the renamed symbol?
+
+🚀 This is because `ref` will find `get_api_client` as `client_factory` when inspecting `mymodule.tasks` module,
+and return `mymodule.tasks.client_factory`.
+
+We can also use ref with `patch.object()` in order to patch a single instance. Consider the following code:
+
+```python
+from unittest.mock import patch
+from mymodule.clients import APIClient
+
+def test() -> None:
+    client = APIClient()
+    with patch.object(client, "_do_request"):
+        ...
+```
+
+🚀 By specifying `obj=True` to `ref`, you will obtain a `Tuple[instance, attribute_to_patch_as_a_string]` that you
+can unpack to `patch.object()`:
+
+```python
+from unittest.mock import patch
+from coveo_testing.mocks import ref
+from mymodule.clients import APIClient
+
+def test() -> None:
+    client = APIClient()
+    with patch.object(*ref(client._do_request, obj=True)):
+        ...
+```
+
+Please refer to the docstring of `ref` for argument usage information.
+
+## Common Mock Recipes
+
+### Mock something globally without context
+#### Option 1: by leveraging the import mechanism
+
+To mock something globally without regards for the context, it has to be accessed through a dot `.` by the context.
+
+For instance, consider this test:
+
+```python
+from http.client import HTTPResponse
+from unittest.mock import patch, MagicMock
+from coveo_testing.mocks import ref
+
+from mymodule.tasks import process
+
+
+@patch(*ref(HTTPResponse.close))
+def test(http_response_close_mock: MagicMock) -> None:
+    assert process()
+```
+
+The target is `HTTPResponse.close`, which lives in the `http.client` module.
+The contextof the test is the `process` function, which lives in the `mymodule.tasks` module.
+Let's take a look at `mymodule.tasks`'s source code:
+
+
+```python
+from http import client
+
+def process() -> bool:
+    _ = client.HTTPResponse(...)  # of course this is fake, but serves the example
+    return ...
+```
+
+Since `mymodule.tasks` reaches `HTTPResponse` through a dot (i.e.: `client.HTTPResponse`), we can patch `HTTPResponse`
+without using `mymodule.tasks` as the context.
+
+However, if `mymodule.tasks` was written like this:
+
+```python
+from http.client import HTTPResponse
+
+def process() -> bool:
+    _ = HTTPResponse(...)
+    return ...
+```
+
+Then the patch would not affect the object used by the `process` function anymore. However, it would affect any other 
+module that uses the dot to reach `HTTPResponse` since the patch was _still_ applied globally.
+ 
+
+#### Option 2: By wrapping a hidden function
+
+Another approach to mocking things globally is to hide a function behind another, and mock the hidden function.
+This allows modules to use whatever import style they want, and the mocks become straightforward to setup.
+
+Pretend this is `mymodule.clients`:
+
+```python
+class APIClient:
+    ...
+
+def get_api_client() -> APIClient:
+    return _get_api_client()
+
+def _get_api_client() -> APIClient:
+    return APIClient()
+```
+
+And this is `mymodule.tasks`:
+
+```python
+from mymodule.clients import get_api_client
+
+def process() -> bool:
+    return get_api_client() is not None
+```
+
+So you _know_ this works globally, because no one will (should?) import the private one except the test:
+
+```python
+from unittest.mock import patch, MagicMock
+from coveo_testing.mocks import ref
+
+from mymodule.tasks import process
+from mymodule.clients import _get_api_client
+
+
+@patch(*ref(_get_api_client))
+def test(api_client_mock: MagicMock) -> None:
+    assert process()
+```
+
+
+### Mock something for a given context
+
+When you want to mock something for a given module, you must provide a hint to `ref` as the `context` argument.
+
+The hint may be a module, or a function/class defined within that module. "Defined" here means that "def" or "class" 
+was used _in that module_. If the hint was imported into the module, it will not work:
+
+`mymodule.tasks`:
+
+```python
+from mymodule.clients import get_api_client
+
+def process() -> bool:
+    client = get_api_client()
+    return ...
+```
+
+The test, showing 3 different methods that work:
+
+```python
+from unittest.mock import patch, MagicMock
+from coveo_testing.mocks import ref
+
+from mymodule.clients import get_api_client
+from mymodule.tasks import process
+
+# you can pass the module as the context
+import mymodule
+
+@patch(*ref(get_api_client, context=mymodule.tasks))
+def test(get_api_client_mock: MagicMock) -> None:
+    assert process()
+
+# you can pass the module as the context, version 2
+from mymodule import tasks
+    
+@patch(*ref(get_api_client, context=tasks))
+def test(get_api_client_mock: MagicMock) -> None:
+    assert process()
+
+# you can also pass a function or a class defined in the `tasks` module
+from mymodule.tasks import process
+@patch(*ref(get_api_client, context=process))
+def test(get_api_client_mock: MagicMock) -> None:
+    assert process()
+```
+
+The 3rd method is encouraged: provide the function or class that is actually using the `get_api_client` import.
+In our example, that's the `process` function.
+If `process` was ever moved to a different module, it would carry the `get_api_client` import, and the mock would
+be automatically adjusted to target `process`'s new module without changes.
+
+### Mock something for the current context
+
+Sometimes, the test file _is_ the context. When that happens, just pass `__name__` as the context:
+
+```python
+from unittest.mock import patch
+from coveo_testing.mocks import ref
+from mymodule.clients import get_api_client, APIClient
+
+def _prepare_test() -> APIClient:
+    client = get_api_client()
+    ...
+    return client
+    
+@patch(*ref(get_api_client, context=__name__))
+def test() -> None:
+    client = _prepare_test()
+    ...
+```
+
+
+### Mock a method on a class
+
+Since a method cannot be imported and can only be accessed through the use of a dot `.` on a class or instance, 
+you can always patch methods globally:
+
+```python
+with patch(*ref(MyClass.fn)): ...
+```
+
+This is because no module can import `fn`; it has to go through an import of `MyClass`.
+
+### Mock a method on one instance of a class
+
+Simply add `obj=True` and use `patch.object()`:
+
+```python
+with patch.object(*ref(instance.fn, obj=True)): ...
+```
+
+
+### Mock an attribute on a class/instance/module/function/object/etc
+
+`ref` cannot help with this task:
+- You cannot refer an attribute that exists (you would pass the value, not a reference)
+- You cannot refer an attribute that doesn't exist (because it doesn't exist!)
+
+For this, there's no going around hardcoding the attribute name in a string:
+
+```python
+class MyClass:
+    def __init__(self) -> None:
+        self.a = 1
+
+
+def test_attr() -> None:
+    instance = MyClass()
+    with patch.object(instance, "a", new=2):
+        assert instance.a == 2
+        assert MyClass().a == 1
+```
+
+This sometimes work when patching **instances**. 
+The example works because `a` is a simple attribute that lives in `instance.__dict__` and `patch.object` knows
+about that.
+
+But if you tried to patch `MyClass` instead of `instance`, `mock.patch` would complain that there's no 
+such thing as `a` over there.
+Thus, patching an attribute globally will most likely result in a lot of wasted time, and should be avoided.
+
+There's no way to make the example work with `ref` because there's no way to refer `instance.a` without actually
+getting the value of `a`, unless we hardcode a string, which defeats the purpose of `ref` completely.
+
+
+### Mock a property
+
+You can only patch a property globally, through its class:
+
+```python
+class MyClass:
+    @property
+    def get(self) -> bool:
+        return False
+```
+
+```python
+from unittest.mock import PropertyMock, patch, MagicMock
+from coveo_testing.mocks import ref
+
+from mymodule import MyClass
+
+@patch(*ref(MyClass.get), new_callable=PropertyMock, return_value=True)
+def test(my_class_get_mock: MagicMock) -> None:
+    assert MyClass().get == True
+    my_class_get_mock.assert_called_once()
+```
+
+You **cannot** patch a property on an instance, this is a limitation of `unittest.mock` because of the way
+properties work.
+If you try, `mock.patch.object()` will complain that the property is read only.
+
+
+### Mock a classmethod or staticmethod on a specific instance
+
+When inspecting these special methods on an instance, `ref` ends up finding the class instead of the instance.
+
+Therefore, `ref` is unable to return a `Tuple[instance, function_name]`.
+It would return `Tuple[class, function_name]`, resulting in a global patch. 😱
+
+But `ref` will detect this mistake, and will raise a helpful exception if it cannot return an instance when you
+specified `obj=True`.
+
+For this particular scenario, the workaround is to provide the instance as the context:
+
+```python
+from unittest.mock import patch
+from coveo_testing.mocks import ref
+
+
+class MyClass:
+    @staticmethod
+    def get() -> bool:
+        return False
+
+    
+def test() -> None:
+    instance = MyClass()
+    with patch.object(*ref(instance.get, context=instance, obj=True)) as fn_mock:
+        assert instance.get == True
+        assert MyClass().get == False  # new instances are not affected by the object mock
+        fn_mock.assert_called_once()
+```
+
+Some may prefer a more semantically-correct version by specifying the target through the class instead of the 
+instance. In the end, these are all equivalent:
+
+```python
+with patch.object(instance, "get"): 
+    ...
+
+with patch.object(*ref(instance.get, context=instance, obj=True)): 
+    ...
+
+with patch.object(*ref(MockClass.get, context=instance, obj=True)): 
+    ...
+```
+
+In this case, the version without ref is much shorter and arguably more pleasant for the eye, but `get` can no longer
+be renamed without altering the tests.

--- a/coveo-testing/coveo_testing/mocks.py
+++ b/coveo-testing/coveo_testing/mocks.py
@@ -273,7 +273,7 @@ def _translate_reference_to_another_module(
 
         if len(symbols_found) > 1:
             raise DuplicateSymbol(
-                f"Duplicate symbols found for {symbol_to_find} in {module.__name__}: {symbols_found}"
+                f"Duplicate symbols found for {symbol_to_find} in {module.__name__}: {symbols_found=}"
             )
 
         return new_reference.with_symbol(symbols_found[0])
@@ -340,78 +340,27 @@ def ref(
     Returns a tuple meant to be unpacked into the `mock.patch` or `mock.patch.object` functions in order to enable
     refactorable mocks.
 
+    The idea is to provide the thing to mock as the target, and sometimes, the thing that is being tested
+    as the context. Refer to `coveo-testing`'s readme to better understand when a context is necessary.
+
+    For example, pass the `HTTPResponse` class as the target and the `my_module.function_to_test` function
+    as the context, so that `my_module.HTTPResponse` becomes mocked (and not httplib.client.HTTPResponse).
+
+    The readme in this repository offers a lot of explanations, examples and recipes on how to mock things properly and
+    when we don't need to provide a `context` argument.
+
+    -- param: context
     In order to target the module where the mock will be used, use the `context` argument. It can be either:
         - A module name as a string (e.g.: "coveo_testing.logging", but more importantly, __name__)
         - A symbol that belongs to the module to patch (i.e.: any function or class defined in that module)
         - An instance, when patching special functions with `obj=True`
 
+        e.g.: mock.patch(*ref(boto3, context=function_that_uses_boto3))
 
-    The "tl;dr" is to provide the thing to mock as the target, and the thing that is being tested as the context.
-    For instance, pass the `HTTPResponse` class as the target and the `my_module.function_to_test` function
-    as the context, so that `my_module.HTTPResponse` will be mocked (and not httplib.client.HTTPResponse).
+    -- param: obj
+    In order to patch a single instance with `patch.object`, specify `obj=True`:
 
-
-    Note that the import style in the target module matters. To mock `HTTPResponse.get_headers`:
-
-    - If `my_module` does `from httplib.client import HTTPResponse`:
-        You must `*ref(HTTPResponse.get_headers, context=something_defined_in_my_module)`
-
-    - If `my_module` does `from httplib import client` or `import httplib`:
-        You may `*ref(HTTPResponse.get_headers)` without context, since a dot `.` is involved.
-
-
-    In order to unpack into `mock.patch.object`, set `obj=True`. The return value will
-    be a tuple(object, attribute). Some special objects such as classmethods will require you to
-    pass the instance as a context as well. If it's the case, an exception will let you know.
-
-    Examples:
-
-    How to patch a module-level symbol, such as a function or class, for any given module:
-
-        with mock.patch(*ref(MyClass, context=fn)):
-            ...
-
-        - In this example, we want to test `fn`, which is defined in module A.
-        - Module A imports `MyClass` from module B.
-        - Therefore, MyClass's reference is `B.MyClass`.
-        - `fn` uses MyClass.
-        - If we used `mock.patch("B.MyClass")`, then it would not affect module A's namespace where `fn` resides.
-        - Therefore, `fn` would still have the original B.MyClass symbol in its namespace.
-        - The correct method is to use `mock.patch("A.MyClass")` even though MyClass is defined in B.
-        - This is what `context` achieves. It will return the reference to `MyClass` for the namespace context of `fn`.
-
-    How to patch a module-level symbol, such as a function or class, for the current module:
-
-        with mock.patch(*ref(MyClass, context=__name__)):
-            ...
-
-        - In this example, the unit test imports and use `MyClass` directly, which belongs to another module.
-        - Therefore, it has to provide itself as the context.
-        - Therefore, use the `__name__` shortcut to provide the current module as the context.
-
-    How to patch a function or class on an instance:
-
-        instance = MyClass()
-        with mock.patch.object(*ref(instance.fn, obj=True)):
-            ...
-
-        - In this example, we want to patch `fn` exclusively on this instance of `MyClass`.
-        - To achieve this, we use the `mock.patch.object` function instead.
-        - Usually, we don't need a context when using `obj=True`.
-        - Therefore, the whole A vs B saga doesn't apply!
-        - The `obj=True` switch will cause the return value to be (instance, "fn") in this case.
-        - Therefore, the `mock.patch.object` will target the `fn` function on your instance.
-
-    How to patch a renamed symbol / more info about `context`:
-
-        with mock.patch(*ref(MyClass, context=something_defined_in_module_being_tested)):
-
-        - If you provide the context, we will inspect the context's module and fish for the object.
-        - You can provide either the renamed class or the original class as the target.
-        - You must provide the context where the renamed symbol can be found.
-        - The context CANNOT be the renamed class. It has to be the context module, or a symbol defined within.
-        - Caveat: If you happen to have the same object defined as multiple names in the same module,
-          a DuplicateSymbol exception will be raised because the mock target becomes ambiguous.
+        e.g.: mock.patch.object(*ref(instance.fn, obj=True))
     """
     if isinstance(target, Mock) or isinstance(context, Mock):
         raise UsageError("Mocks cannot be resolved.")
@@ -439,7 +388,8 @@ def ref(
                 If you are trying to patch a classmethod or staticmethod on a specific instance, you must provide that
                 instance as the `context` argument.
                 
-                If the goal was to patch globally, remove the {obj=} argument, provide a context and use patch().
+                If the goal was to patch globally, remove the {obj=} argument, optionally provide a context 
+                and use patch().
                 
                 If you believe this is a mistake, you can try to use `_bypass_context_check` and see if it works.
                 If it does, please submit an issue with a quick test that reproduces the issue! <3

--- a/coveo-testing/coveo_testing/mocks.py
+++ b/coveo-testing/coveo_testing/mocks.py
@@ -131,23 +131,28 @@ def resolve_mock_target(target: Any) -> str:
 
 
 @overload
-def ref(target: Any) -> Tuple[str]: ...
+def ref(target: Any) -> Tuple[str]:
+    ...
 
 
 @overload
-def ref(target: Any, *, context: Optional[Any]) -> Tuple[str]: ...
+def ref(target: Any, *, context: Optional[Any]) -> Tuple[str]:
+    ...
 
 
 @overload
-def ref(target: Any, *, obj: Literal[True]) -> Tuple[str, str]: ...
+def ref(target: Any, *, obj: Literal[True]) -> Tuple[str, str]:
+    ...
 
 
 @overload
-def ref(target: Any, *, obj: Literal[False]) -> Tuple[str]: ...
+def ref(target: Any, *, obj: Literal[False]) -> Tuple[str]:
+    ...
 
 
 @overload
-def ref(target: Any, *, context: Optional[Any], obj: Literal[False]) -> Tuple[str]: ...
+def ref(target: Any, *, context: Optional[Any], obj: Literal[False]) -> Tuple[str]:
+    ...
 
 
 # It's an error to provide `obj=True` and a context, but there was no way to express this overload at the moment.

--- a/coveo-testing/coveo_testing/mocks.py
+++ b/coveo-testing/coveo_testing/mocks.py
@@ -3,7 +3,7 @@ import inspect
 from dataclasses import dataclass
 from unittest.mock import Mock
 from types import ModuleType
-from typing import Any, Tuple, Optional, Union
+from typing import Any, Tuple, Optional, Union, overload, Literal
 
 
 class CannotFindSymbol(AttributeError):
@@ -128,6 +128,31 @@ def resolve_mock_target(target: Any) -> str:
     by value and not by reference; they contain no metadata to inspect.
     """
     return f"{target.__module__}.{target.__name__}"
+
+
+@overload
+def ref(target: Any) -> Tuple[str]: ...
+
+
+@overload
+def ref(target: Any, *, context: Optional[Any]) -> Tuple[str]: ...
+
+
+@overload
+def ref(target: Any, *, obj: Literal[True]) -> Tuple[str, str]: ...
+
+
+@overload
+def ref(target: Any, *, obj: Literal[False]) -> Tuple[str]: ...
+
+
+@overload
+def ref(target: Any, *, context: Optional[Any], obj: Literal[False]) -> Tuple[str]: ...
+
+
+# It's an error to provide `obj=True` and a context, but there was no way to express this overload at the moment.
+# @overload
+# def ref(target: Any, *, context: Any, obj: Literal[True]) -> Tuple[str]: ...
 
 
 def ref(

--- a/coveo-testing/tests_testing/mock_module/__init__.py
+++ b/coveo-testing/tests_testing/mock_module/__init__.py
@@ -1,0 +1,22 @@
+from tests_testing.mock_module.inner import (
+    MockClass,
+    inner_function,
+    inner_function_wrapper,
+    MockClassToRename as RenamedClass,
+)
+
+
+def call_inner_function_from_another_module() -> str:
+    return inner_function()
+
+
+def call_inner_function_wrapper_from_another_module() -> str:
+    return inner_function_wrapper()
+
+
+def return_renamed_mock_class_instance() -> RenamedClass:
+    return RenamedClass()
+
+
+class MockSubClass(MockClass):
+    ...

--- a/coveo-testing/tests_testing/mock_module/__init__.py
+++ b/coveo-testing/tests_testing/mock_module/__init__.py
@@ -18,5 +18,9 @@ def return_renamed_mock_class_instance() -> RenamedClass:
     return RenamedClass()
 
 
+def return_property_from_renamed_mock_class_instance() -> str:
+    return RenamedClass().property  # type: ignore[no-any-return]  # mypy doesn't like the custom property :shrug:
+
+
 class MockSubClass(MockClass):
     ...

--- a/coveo-testing/tests_testing/mock_module/inner.py
+++ b/coveo-testing/tests_testing/mock_module/inner.py
@@ -1,3 +1,6 @@
+from typing import Any, Callable
+
+
 def inner_function() -> str:
     return "Un pangolin ça marche comme M.Burns."
 
@@ -9,11 +12,19 @@ def inner_function_wrapper() -> str:
 class MockClass:
     class NestedClass:
         class DoubleNestedClass:
+            @property
+            def property(self) -> str:
+                return "Genre que leur pattes avant sont trop occuppé à dire 'excellent'."
+
             def instance_function(self) -> str:
                 return "Sont vraiment cute!"
 
     def instance_function(self) -> str:
         return "Faudrait tu puisses voir la vidéo sur reddit."
+
+    @property
+    def property(self) -> str:
+        return "Ouain."
 
     @classmethod
     def classmethod(cls) -> str:
@@ -24,9 +35,19 @@ class MockClass:
         return "L'histoire est pas mal finie!"
 
 
+def _hidden_getter(_self: "MockClassToRename") -> str:
+    return "À prochaine!"
+
+
 class MockClassToRename:
     def instance_function(self) -> str:
-        return "À prochaine!"
+        return "Bon àprochainaaaaage!"
+
+    def hidden_property_setter(self, value: str) -> None:
+        ...
+
+    # this is the custom form of the @property decorator
+    property = property(_hidden_getter, hidden_property_setter)
 
 
 def inner_mock_class_factory() -> MockClass:

--- a/coveo-testing/tests_testing/mock_module/inner.py
+++ b/coveo-testing/tests_testing/mock_module/inner.py
@@ -1,0 +1,33 @@
+def inner_function() -> str:
+    return "Un pangolin ça marche comme M.Burns."
+
+
+def inner_function_wrapper() -> str:
+    return inner_function()
+
+
+class MockClass:
+    class NestedClass:
+        class DoubleNestedClass:
+            def instance_function(self) -> str:
+                return "Sont vraiment cute!"
+
+    def instance_function(self) -> str:
+        return "Faudrait tu puisses voir la vidéo sur reddit."
+
+    @classmethod
+    def classmethod(cls) -> str:
+        return "Tu comprendrais mieux."
+
+    @staticmethod
+    def staticmethod() -> str:
+        return "L'histoire est pas mal finie!"
+
+
+class MockClassToRename:
+    def instance_function(self) -> str:
+        return "À prochaine!"
+
+
+def inner_mock_class_factory() -> MockClass:
+    return MockClass()

--- a/coveo-testing/tests_testing/test_mocks.py
+++ b/coveo-testing/tests_testing/test_mocks.py
@@ -1,27 +1,25 @@
-from typing import Final, Any, Tuple, Optional, Callable, Type
+from typing import Any, Callable, Final, Optional, Tuple, Type
 from unittest import mock
 from unittest.mock import PropertyMock
 
 import pytest
-
+from coveo_testing.mocks import _PythonReference, ref
 from coveo_testing.parametrize import parametrize
-from coveo_testing.mocks import PythonReference, ref
-
+from tests_testing.mock_module import MockClass as TransitiveMockClass
+from tests_testing.mock_module import (
+    MockSubClass,
+    RenamedClass,
+    call_inner_function_from_another_module,
+    call_inner_function_wrapper_from_another_module,
+    return_property_from_renamed_mock_class_instance,
+    return_renamed_mock_class_instance,
+)
 from tests_testing.mock_module.inner import (
     MockClass,
+    MockClassToRename,
     inner_function,
     inner_function_wrapper,
     inner_mock_class_factory,
-    MockClassToRename,
-)
-from tests_testing.mock_module import (
-    MockClass as TransitiveMockClass,
-    call_inner_function_from_another_module,
-    call_inner_function_wrapper_from_another_module,
-    MockSubClass,
-    RenamedClass,
-    return_renamed_mock_class_instance,
-    return_property_from_renamed_mock_class_instance,
 )
 
 MOCKED: Final[str] = "mocked"
@@ -57,14 +55,14 @@ MOCKED: Final[str] = "mocked"
     ),
 )
 def test_python_reference(target: Any, expected: Tuple[str, Optional[str], Optional[str]]) -> None:
-    """The PythonReference object references the original module."""
-    assert (reference := PythonReference.from_any(target)) == PythonReference(*expected)
+    """The _PythonReference object references the original module."""
+    assert (reference := _PythonReference.from_any(target)) == _PythonReference(*expected)
     _ = reference.import_symbol()
 
 
 @parametrize(("target", "expected"), _TEST_CASES)
 def test_ref(target: Any, expected: Tuple[str, Optional[str], Optional[str]]) -> None:
-    """`ref` without a context is similar to PythonReference."""
+    """`ref` without a context is similar to _PythonReference."""
     assert ref(target) == (".".join(filter(bool, expected)),)
 
 

--- a/coveo-testing/tests_testing/test_mocks.py
+++ b/coveo-testing/tests_testing/test_mocks.py
@@ -201,12 +201,12 @@ def test_ref_overloads() -> None:
 
     # noinspection PyUnreachableCode
     # these are the correct usages
-    tuple_one_string(ref('target'))
-    tuple_one_string(ref('target'))
-    tuple_one_string(ref('target', context="context"))
-    tuple_two_strings(ref('target', obj=True))
+    tuple_one_string(ref("target"))
+    tuple_one_string(ref("target"))
+    tuple_one_string(ref("target", context="context"))
+    tuple_two_strings(ref("target", obj=True))
 
     # these are incorrect
-    tuple_one_string(ref('target', obj=True))  # type: ignore[arg-type]
-    tuple_two_strings(ref('target', context='context'))  # type: ignore[arg-type]
-    tuple_two_strings(ref('target'))  # type: ignore[arg-type]
+    tuple_one_string(ref("target", obj=True))  # type: ignore[arg-type]
+    tuple_two_strings(ref("target", context="context"))  # type: ignore[arg-type]
+    tuple_two_strings(ref("target"))  # type: ignore[arg-type]

--- a/coveo-testing/tests_testing/test_mocks.py
+++ b/coveo-testing/tests_testing/test_mocks.py
@@ -1,6 +1,8 @@
 from typing import Final, Any, Tuple, Optional, Callable, Type
 from unittest import mock
 
+import pytest
+
 from coveo_testing.parametrize import parametrize
 from coveo_testing.mocks import PythonReference, ref
 
@@ -187,3 +189,24 @@ def test_ref_with_mock_patch_object() -> None:
 
         # new instances are not impacted, of course
         assert MockClass().instance_function() != MOCKED
+
+
+@pytest.mark.skip(reason="Annotation test only.")
+def test_ref_overloads() -> None:
+    def tuple_one_string(arg: Tuple[str]) -> None:
+        ...
+
+    def tuple_two_strings(arg: Tuple[str, str]) -> None:
+        ...
+
+    # noinspection PyUnreachableCode
+    # these are the correct usages
+    tuple_one_string(ref('target'))
+    tuple_one_string(ref('target'))
+    tuple_one_string(ref('target', context="context"))
+    tuple_two_strings(ref('target', obj=True))
+
+    # these are incorrect
+    tuple_one_string(ref('target', obj=True))  # type: ignore[arg-type]
+    tuple_two_strings(ref('target', context='context'))  # type: ignore[arg-type]
+    tuple_two_strings(ref('target'))  # type: ignore[arg-type]

--- a/coveo-testing/tests_testing/test_mocks.py
+++ b/coveo-testing/tests_testing/test_mocks.py
@@ -1,0 +1,189 @@
+from typing import Final, Any, Tuple, Optional, Callable, Type
+from unittest import mock
+
+from coveo_testing.parametrize import parametrize
+from coveo_testing.mocks import PythonReference, ref
+
+from tests_testing.mock_module.inner import (
+    MockClass,
+    inner_function,
+    inner_function_wrapper,
+    inner_mock_class_factory,
+    MockClassToRename,
+)
+from tests_testing.mock_module import (
+    MockClass as TransitiveMockClass,
+    call_inner_function_from_another_module,
+    call_inner_function_wrapper_from_another_module,
+    MockSubClass,
+    RenamedClass,
+    return_renamed_mock_class_instance,
+)
+
+MOCKED: Final[str] = "mocked"
+
+
+@parametrize(
+    ("target", "expected"),
+    _TEST_CASES := (
+        (
+            inner_function,
+            ((_INNER_MODULE := "tests_testing.mock_module.inner"), "inner_function", None),
+        ),
+        (
+            MockClass.instance_function,
+            (_INNER_MODULE, "MockClass", "instance_function"),
+        ),
+        (MockClass.classmethod, (_INNER_MODULE, "MockClass", "classmethod")),
+        (MockClass.staticmethod, (_INNER_MODULE, "MockClass", "staticmethod")),
+        (MockClass, (_INNER_MODULE, "MockClass", None)),
+        # this is equivalent to the previous test: the original module always prevails.
+        (TransitiveMockClass, (_INNER_MODULE, "MockClass", None)),
+        (
+            MockClass.NestedClass.DoubleNestedClass.instance_function,
+            (
+                _INNER_MODULE,
+                "MockClass",
+                "NestedClass.DoubleNestedClass.instance_function",
+            ),
+        ),
+        # modules as string works too
+        (__name__, ("tests_testing.test_mocks", None, None)),
+    ),
+)
+def test_python_reference(target: Any, expected: Tuple[str, Optional[str], Optional[str]]) -> None:
+    """The PythonReference object references the original module."""
+    assert (reference := PythonReference.from_any(target)) == PythonReference(*expected)
+    _ = reference.import_symbol()
+
+
+@parametrize(("target", "expected"), _TEST_CASES)
+def test_ref(target: Any, expected: Tuple[str, Optional[str], Optional[str]]) -> None:
+    """`ref` without a context is similar to PythonReference."""
+    assert ref(target) == (".".join(filter(bool, expected)),)
+
+
+@parametrize(
+    ("target", "context", "expected"),
+    (
+        # with a context, we automatically find the correct object
+        (inner_function, inner_function_wrapper, "tests_testing.mock_module.inner.inner_function"),
+        (
+            inner_function,
+            call_inner_function_from_another_module,
+            "tests_testing.mock_module.inner_function",
+        ),
+        (
+            inner_function,
+            call_inner_function_wrapper_from_another_module,
+            "tests_testing.mock_module.inner_function",
+        ),
+        (
+            MockClass.instance_function,
+            call_inner_function_from_another_module,
+            "tests_testing.mock_module.MockClass.instance_function",
+        ),
+        (
+            MockClassToRename.instance_function,
+            call_inner_function_from_another_module,
+            "tests_testing.mock_module.RenamedClass.instance_function",
+        ),
+        (
+            MockClassToRename,
+            call_inner_function_from_another_module,
+            "tests_testing.mock_module.RenamedClass",
+        ),
+    ),
+)
+def test_ref_context(target: Any, context: Any, expected: str) -> None:
+    """
+    `ref` with a context will fish for the symbol in context's module.
+    This covers the cases where the symbol is renamed during the import.
+    """
+    assert ref(target, context=context) == (expected,)
+
+
+@parametrize(
+    ("to_patch", "check"),
+    (
+        (inner_function, inner_function_wrapper),
+        # With a wrapper, you don't have to think about the context.
+        (inner_function, call_inner_function_wrapper_from_another_module),
+        (MockClass, inner_mock_class_factory),
+    ),
+)
+def test_ref_symbol_called_from_wrapper(to_patch: Any, check: Callable[[], Any]) -> None:
+    """
+    Wrapping a symbol behind another callable in the same module is a clever way to make a mock work from everywhere,
+    but requires changes to the source code.
+    """
+    with mock.patch(*ref(to_patch), return_value=MOCKED) as mocked_fn:
+        assert check() == MOCKED
+        mocked_fn.assert_called_once()
+
+
+@parametrize(
+    ("to_patch", "check"),
+    (
+        (inner_function, call_inner_function_from_another_module),
+        (RenamedClass, return_renamed_mock_class_instance),
+        # in reality, RenamedClass is MockClassToRename; it's the context that is important here.
+        # same test again, but without specifying "RenamedClass".
+        (MockClassToRename, return_renamed_mock_class_instance),
+    ),
+)
+def test_ref_function_different_module(to_patch: Any, check: Callable[[], Any]) -> None:
+    """In order to make a mock work for a different module, we use `context`."""
+    with mock.patch(*ref(to_patch, context=check), return_value=MOCKED) as mocked_fn:
+        assert check() == MOCKED
+        mocked_fn.assert_called_once()
+
+
+@parametrize(
+    ("to_patch", "calling_type"),
+    (
+        (MockClass.instance_function, MockClass),
+        (MockClass.instance_function, MockSubClass),
+        (MockClass.instance_function, TransitiveMockClass),
+        (MockSubClass.instance_function, MockSubClass),
+        (TransitiveMockClass.instance_function, TransitiveMockClass),
+        # comical example because why not
+        (
+            MockClass.NestedClass.DoubleNestedClass.instance_function,
+            TransitiveMockClass.NestedClass.DoubleNestedClass,
+        ),
+    ),
+)
+def test_ref_instance_functions(to_patch: Any, calling_type: Type[MockClass]) -> None:
+    """Mocking a function on a class is trivial, and works across modules."""
+    with mock.patch(*ref(to_patch), return_value=MOCKED) as mocked_fn:
+        assert calling_type().instance_function() == MOCKED
+        mocked_fn.assert_called_once()
+
+
+@parametrize("context", (__name__, test_python_reference))
+def test_ref_class(context: Any) -> None:
+    """
+    You can patch classes directly, in order to return whatever. But the module becomes important
+    again, and behaves exactly like functions at the module level.
+    """
+    with mock.patch(*ref(MockClass, context=context), return_value=1) as mocked_class:
+        assert MockClass() == 1
+        mocked_class.assert_called_once()
+
+
+def test_ref_with_mock_patch_object() -> None:
+    """
+    In order to unpack into `mock.patch.object`, we use `obj=True`.
+    It will only affect the instance passed in the target.
+    """
+
+    instance = MockClass()
+    with mock.patch.object(
+        *ref(instance.instance_function, obj=True), return_value=MOCKED
+    ) as mocked_fn:
+        assert instance.instance_function() == MOCKED
+        mocked_fn.assert_called_once()
+
+        # new instances are not impacted, of course
+        assert MockClass().instance_function() != MOCKED


### PR DESCRIPTION
Sorry for the length of this one; at the very least, a lot of it is documentation.

This should work for the vast majority of the "standard python stuff". I've had very good success refactoring mocks with this so far. Sometimes, the "global patch warning" exception would warn me, and it turned out to be right; these cases could be simplified by calling `patch()` instead.

After my own review: I need to rewrite the `ref` documentation completely, it's more confusing than it needs to be. Feel free to skip that part since it would probably be very headache-inducing. I'll follow up with a different PR with a proper readme.

