### PR TITLE
coveo-testing // fix references when renamed symbol's original name can be found

### DIFF
--- a/coveo-testing/coveo_testing/mocks.py
+++ b/coveo-testing/coveo_testing/mocks.py
@@ -254,14 +254,18 @@ def _translate_reference_to_another_module(
         - Module C calls `from B import A as RenamedA`
         - Calling with (reference=A, module=C) will return a reference to "C.RenamedA"
     """
+    symbol_to_find = reference.import_symbol()
     new_reference = reference.with_module(module if isinstance(module, str) else module.__name__)
 
     try:
-        _ = new_reference.import_symbol()
+        imported = new_reference.import_symbol()
+        if imported is not symbol_to_find:
+            raise CannotFindSymbol(
+                f"Importing {new_reference} resulted in {imported} but {symbol_to_find} was expected."
+            )
     except CannotFindSymbol:
         # symbol was renamed? fish!
         module = new_reference.import_module()
-        symbol_to_find = reference.import_symbol()
         symbols_found = tuple(
             symbol_name
             for symbol_name, symbol in module.__dict__.items()

--- a/coveo-testing/tests_testing/mock_module/shadow_rename.py
+++ b/coveo-testing/tests_testing/mock_module/shadow_rename.py
@@ -1,0 +1,5 @@
+from tests_testing.mock_module.inner import inner_function as renamed_else_shadowed
+
+
+def inner_function() -> None:
+    """Before the fix, we would use anything that matched the name without looking if it was the right thing."""

--- a/coveo-testing/tests_testing/test_mocks.py
+++ b/coveo-testing/tests_testing/test_mocks.py
@@ -3,7 +3,7 @@ from unittest import mock
 from unittest.mock import PropertyMock, Mock, MagicMock
 
 import pytest
-from coveo_testing.mocks import _PythonReference, ref, CannotFindSymbol, UsageError
+from coveo_testing.mocks import _PythonReference, ref, UsageError
 from coveo_testing.parametrize import parametrize
 from tests_testing.mock_module import MockClass as TransitiveMockClass
 from tests_testing.mock_module import (
@@ -21,6 +21,8 @@ from tests_testing.mock_module.inner import (
     inner_function_wrapper,
     inner_mock_class_factory,
 )
+from tests_testing.mock_module import shadow_rename
+
 
 MOCKED: Final[str] = "mocked"
 
@@ -106,6 +108,17 @@ def test_ref(target: Any, expected: Tuple[str, Optional[str], Optional[str]]) ->
             MockClassToRename.property,
             call_inner_function_from_another_module,
             "tests_testing.mock_module.RenamedClass.property",
+        ),
+        # the 2 following cases test an edge case with renames
+        (
+            shadow_rename.inner_function,
+            shadow_rename,
+            "tests_testing.mock_module.shadow_rename.inner_function",
+        ),
+        (
+            inner_function,
+            shadow_rename,
+            "tests_testing.mock_module.shadow_rename.renamed_else_shadowed",
         ),
     ),
 )


### PR DESCRIPTION
When the name was found in the module we would use it, no questions asked. In some cases, it's not the droid we were looking for.