### PR TITLE
(coveo-settings) Add Setting.get_or_raise() method

### DIFF
--- a/coveo-settings/README.md
+++ b/coveo-settings/README.md
@@ -42,6 +42,7 @@ DATABASE_USE_SSL = BoolSetting('project.database.ssl')
 
 # this method will raise an exception if the setting has no value and no fallback
 use_ssl = bool(DATABASE_USE_SSL)
+use_ssl = DATABASE_USE_SSL.get_or_raise()
 assert use_ssl in [True, False]
 
 # this method will not raise an exception
@@ -84,7 +85,7 @@ ENV = StringSetting("environment", fallback="dev", validation=InSequence("prod",
 You can register custom redirection schemes in order to support any data source.
 
 Much like `https://` is a clear scheme, you may register callback functions to trigger when the value of a setting
-starts with the scheme(s) you define. For instance, let's support a custom API and a file storage: 
+starts with the scheme(s) you define. For instance, let's support a custom API and a file storage:
 
 ```python
 from coveo_settings import settings_adapter, StringSetting, ConfigValue
@@ -95,13 +96,13 @@ def internal_api_adapter(key: str) -> ConfigValue:
     # the scheme was automatically removed for convenience; only the resource remains
     assert "internal-api::" not in key
     return "internal api"  # implement logic to obtain value from internal api
-    
+
 
 @settings_adapter("file::", strip_scheme=False)
 def file_adapter(key: str) -> ConfigValue:
     # you can keep the scheme by specifying `strip_scheme=False`
     assert key.startswith("file::")
-    return "file adapter"  # implement logic to parse the key and retrieve the setting value 
+    return "file adapter"  # implement logic to parse the key and retrieve the setting value
 
 
 assert StringSetting('...', fallback="internal-api::settings/user-name").value == "internal api"
@@ -118,13 +119,13 @@ os.environ['test'] = "internal-api::url"
 assert REDIRECT_ME.value == "internal api"
 ```
 
-Keep in mind that there's no restriction on the prefix scheme; it's your responsibility to pick something unique 
+Keep in mind that there's no restriction on the prefix scheme; it's your responsibility to pick something unique
 that can be set as the value of an environment variable.
 
 
 ### Redirection is recursive
 
-The value of a redirection may be another redirection and may juggle between adapters. 
+The value of a redirection may be another redirection and may juggle between adapters.
 A limit of 50 redirections is supported:
 
 ```python
@@ -143,7 +144,7 @@ assert StringSetting("my-setting").value == "final value"
 ### Builtin environment redirection
 
 The builtin redirection scheme `env->` can be used to redirect to a different environment variable.
-The example below demonstrates the deprecation/migration of `my-setting` into `new-setting`: 
+The example below demonstrates the deprecation/migration of `my-setting` into `new-setting`:
 
 ```python
 import os
@@ -164,7 +165,7 @@ This is particularly useful in redirection scenarios to avoid repeating requests
 
 ## Setting the value
 
-You can override the value using `setting.value = "some value"` and clear the override with `setting.value = None`. 
+You can override the value using `setting.value = "some value"` and clear the override with `setting.value = None`.
 Clearing the override resumes the normal behavior of the environment variables and the fallback value, if set.
 
 This is typically used as a way to propagate CLI switches globally.

--- a/coveo-settings/coveo_settings/setting_abc.py
+++ b/coveo-settings/coveo_settings/setting_abc.py
@@ -169,6 +169,7 @@ class Setting(SupportsInt, SupportsFloat, Generic[T], Container, Iterable):
         return settings_adapter.is_redirect(self._get_value_before_redirections())
 
     def get_or_raise(self) -> T:
+        """Return the value or raise an MandatoryConfigurationError if not set."""
         self.raise_if_missing()
         return self.value
 

--- a/coveo-settings/coveo_settings/setting_abc.py
+++ b/coveo-settings/coveo_settings/setting_abc.py
@@ -168,6 +168,10 @@ class Setting(SupportsInt, SupportsFloat, Generic[T], Container, Iterable):
         """True if the value invokes a custom adapter."""
         return settings_adapter.is_redirect(self._get_value_before_redirections())
 
+    def get_or_raise(self) -> T:
+        self.raise_if_missing()
+        return self.value
+
     def get_if_set(self, default: T) -> T:
         """Return the value, or a default if not set."""
         return self.value if self.is_set else default

--- a/coveo-settings/pyproject.toml
+++ b/coveo-settings/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coveo-settings"
-version = "2.0.8"
+version = "2.1.0"
 description = "Settings driven by environment variables."
 license = "Apache-2.0"
 readme = "README.md"

--- a/coveo-settings/tests_settings/test_settings.py
+++ b/coveo-settings/tests_settings/test_settings.py
@@ -709,6 +709,24 @@ def test_setting_get() -> None:
 
 
 @UnitTest
+def test_setting_get_or_raise_no_fallback() -> None:
+    with pytest.raises(MandatoryConfigurationError):
+        StringSetting("any").get_or_raise()
+
+
+@UnitTest
+def test_setting_get_or_raise_fallback() -> None:
+    assert StringSetting("any", fallback="fallback").get_or_raise() == "fallback"
+
+
+@UnitTest
+def test_setting_get_or_raise_value() -> None:
+    key = "test.setting.get_or_raise"
+    os.environ[key] = "env value"
+    assert StringSetting(key, fallback="fallback").get_or_raise() == "env value"
+
+
+@UnitTest
 def test_setting_cached() -> None:
     env = "test.settings.cached"
     setting = StringSetting(env, cached=True)


### PR DESCRIPTION
Currently, `coveo-settings` effectively supports getting the value in two ways:

- If the value is optional: `MY_SETTING.value`
- If the value is required: `str(MY_SETTING)` (the type here changes depending on the subclass of `Setting` used)

This PR adds a new way of getting the value out of a setting if the value is required: 

```py
MY_SETTING.get_or_raise()
``` 

This new way of getting a required value out of a setting is more intuitive for people who are not familiar with `coveo-settings` and are not aware of how the "cast" functionality works.

An added benefit of this method is that you no longer need to specify the output type when getting the value out of a setting. This means that if you have a `StringSetting` you get a `str` out, if you have an `IntSetting` you get an `int` out and so on.