### PR TITLE
flex // factory adapter

### DIFF
--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -197,6 +197,41 @@ that can be used to bend the framework if you accept bearing the consequences:
   - The payload `value` received by the adapter is not a copy, modifications will be honored.
 
 
+### Factory Adapters
+
+Some types don't play well with keyword arguments. For instance, using the `datetime` class is much more convenient using strings, isoformat() and fromisoformat() than
+having to parse it into the year/month/etc component.
+
+To serialize such types, you can use a factory adapter, which is expected to return the instance instead of the type.
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from coveo_functools import flex
+from coveo_functools.flex.factory_adapter import register_factory_adapter
+
+# Implementation:
+
+def _datetime_factory(value: str) -> datetime:
+  return datetime.fromisoformat(value)
+
+register_factory_adapter(datetime, _datetime_factory)
+
+
+# Demonstration:
+
+@dataclass
+class WithDateTime:
+  timestamp: datetime
+  
+
+timestamp = datetime.utcnow()
+instance = flex.deserialize({"timestamp": timestamp.isoformat()}, hint=WithDateTime)
+assert instance.timestamp == timestamp
+assert isinstance(instance.timestamp, datetime)
+```
+
+
 ### About Abstract classes
 
 There are two ways to deal with abstract classes:

--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -210,12 +210,13 @@ from datetime import datetime
 from coveo_functools import flex
 from coveo_functools.flex.factory_adapter import register_factory_adapter
 
-# Implementation:
+# Implementation of the deserialization:
 
 def _datetime_factory(value: str) -> datetime:
   return datetime.fromisoformat(value)
 
 register_factory_adapter(datetime, _datetime_factory)
+
 
 
 # Demonstration:

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -21,6 +21,7 @@ from coveo_functools.annotations import find_annotations
 from coveo_functools.casing import TRANSLATION_TABLE, unflex
 from coveo_functools.dispatch import dispatch
 from coveo_functools.exceptions import UnsupportedAnnotation
+from coveo_functools.flex.factory_adapter import get_factory_adapter
 from coveo_functools.flex.helpers import resolve_hint
 from coveo_functools.flex.serializer import SerializationMetadata
 from coveo_functools.flex.subclass_adapter import get_subclass_adapter
@@ -84,6 +85,10 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]]) -> T:
     if adapter := get_subclass_adapter(hint):
         # ask the adapter what the hint should be for this value
         hint = adapter(value)
+
+    elif factory := get_factory_adapter(hint):
+        # factories are expected to return an instance of the correct type, so we can just bypass everything else.
+        return cast(T, factory(value))
 
     if isabstract(hint):
         raise UnsupportedAnnotation(

--- a/coveo-functools/coveo_functools/flex/factory_adapter.py
+++ b/coveo-functools/coveo_functools/flex/factory_adapter.py
@@ -1,0 +1,29 @@
+from typing import Dict, Type, Callable, Any, Optional, TypeVar
+
+from coveo_functools.flex.types import TypeHint
+
+
+T = TypeVar("T")
+
+_factory_adapters: Dict[Type, Callable[[Any], TypeHint]] = {}
+
+
+def register_factory_adapter(hint: TypeHint, factory: Callable[[Any], T]) -> None:
+    """
+    Registers a custom factory for a type.
+
+    The factory will receive the raw payload value. It should return an instance of the proper type.
+    """
+    if hint in _factory_adapters:
+        raise RuntimeError("A factory for this class was already registered.")
+
+    _factory_adapters[hint] = factory
+
+
+def get_factory_adapter(hint: TypeHint) -> Optional[Callable[[Any], T]]:
+    try:
+        hash(hint)
+    except TypeError:
+        return None
+
+    return _factory_adapters.get(hint)

--- a/coveo-functools/tests_functools/test_flex_adapters.py
+++ b/coveo-functools/tests_functools/test_flex_adapters.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Type, Any, Generator, List, Dict, Optional
 
 import pytest
 from coveo_functools.exceptions import UnsupportedAnnotation
 from coveo_functools.flex import deserialize, TypeHint
+from coveo_functools.flex.factory_adapter import register_factory_adapter
 from coveo_functools.flex.subclass_adapter import register_subclass_adapter, _subclass_adapters
 from coveo_testing.parametrize import parametrize
 
@@ -153,3 +155,21 @@ def test_deserialize_adapter_factory_classmethod() -> None:
 
     payload: Dict[str, Any] = {"raw": {"value": "success"}}
     assert deserialize(payload, hint=TestFactory).value == "success"
+
+
+@dataclass
+class TestDatetimeFactory:
+    value: datetime
+
+
+def test_deserialize_adapter_factory_function() -> None:
+    """Tests the factory feature, which expects the instance to be returned instead of the type."""
+
+    def datetime_factory(value: str) -> datetime:
+        return datetime.fromisoformat(value)
+
+    register_factory_adapter(datetime, datetime_factory)
+    test_datetime = datetime.utcnow()
+
+    payload: Dict[str, Any] = {"value": test_datetime.isoformat()}
+    assert deserialize(payload, hint=TestDatetimeFactory).value == test_datetime


### PR DESCRIPTION
The factory adapter is a way to break away from the "keywords args" model and provide quick ways to deserialize data into some builtin types such as datetime.