### PR TITLE
flex strict mode

### DIFF
--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -17,6 +17,10 @@ class PayloadMismatch(Flexception):
     """When the payload doesn't match the target type."""
 
     def __init__(self, value: Any, hint: Any, contains: Any) -> None:
+        self.value = value
+        self.hint = hint
+        self.contains = contains
+
         super().__init__(
             f"I don't know how to fit {type(value)} "
             f"into {hint}{' of ' + str(contains) if contains else ''}"

--- a/coveo-functools/coveo_functools/exceptions.py
+++ b/coveo-functools/coveo_functools/exceptions.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+
 class CoveoFunctoolsException(Exception):
     """Base class for coveo-functools exceptions."""
 
@@ -8,3 +11,13 @@ class Flexception(CoveoFunctoolsException):  # sorry for the pun :socanadian:
 
 class UnsupportedAnnotation(Flexception, NotImplementedError):
     """When an annotation isn't supported."""
+
+
+class PayloadMismatch(Flexception):
+    """When the payload doesn't match the target type."""
+
+    def __init__(self, value: Any, hint: Any, contains: Any) -> None:
+        super().__init__(
+            f"I don't know how to fit {type(value)} "
+            f"into {hint}{' of ' + str(contains) if contains else ''}"
+        )

--- a/coveo-functools/coveo_functools/flex/decorator.py
+++ b/coveo-functools/coveo_functools/flex/decorator.py
@@ -13,8 +13,7 @@ from typing import (
     Type,
 )
 
-from coveo_functools.flex.deserializer import convert_kwargs_for_unpacking
-
+from coveo_functools.flex.deserializer import convert_kwargs_for_unpacking, ErrorBehavior
 
 T = TypeVar("T")
 
@@ -30,27 +29,31 @@ RAW_KEY: Final[str] = "_coveo_functools_flexed_from_"
 
 
 @overload
-def flex() -> Callable[[RealObject], WrappedObject]:
+def flex(*, errors: ErrorBehavior = "deprecated") -> Callable[[RealObject], WrappedObject]:
     ...
 
 
 @overload
-def flex(obj: None) -> Callable[[RealObject], WrappedObject]:
+def flex(
+    obj: None, *, errors: ErrorBehavior = "deprecated"
+) -> Callable[[RealObject], WrappedObject]:
     ...
 
 
 @overload
-def flex(obj: RealClass) -> WrappedClass:
+def flex(obj: RealClass, *, errors: ErrorBehavior = "deprecated") -> WrappedClass:
     ...
 
 
 @overload
-def flex(obj: RealFunction) -> WrappedFunction:
+def flex(obj: RealFunction, *, errors: ErrorBehavior = "deprecated") -> WrappedFunction:
     ...
 
 
 def flex(
     obj: Optional[RealObject] = None,
+    *,
+    errors: ErrorBehavior = "deprecated",
 ) -> Union[WrappedObject, Callable[[RealObject], WrappedObject]]:
     """Wraps `obj` into recursive flexcase magic."""
     if obj is not None:
@@ -73,7 +76,7 @@ def flex(
 
         """
 
-        return _generate_wrapper(obj)
+        return _generate_wrapper(obj, errors=errors)
 
     else:
 
@@ -92,35 +95,35 @@ def flex(
         """
 
         # python's mechanic is going to call us again with the obj as the first (and only) argument to get a wrapper.
-        return flex
+        return functools.partial(flex, errors=errors)
 
 
 @overload
-def _generate_wrapper(obj: RealClass) -> WrappedClass:
+def _generate_wrapper(obj: RealClass, *, errors: ErrorBehavior) -> WrappedClass:
     ...
 
 
 @overload
-def _generate_wrapper(obj: RealFunction) -> WrappedFunction:
+def _generate_wrapper(obj: RealFunction, *, errors: ErrorBehavior) -> WrappedFunction:
     ...
 
 
-def _generate_wrapper(obj: RealObject) -> WrappedObject:
+def _generate_wrapper(obj: RealObject, *, errors: ErrorBehavior) -> WrappedObject:
     """Generates a wrapper over obj."""
     # handle custom objects
     if inspect.isclass(obj):
-        return _generate_class_wrapper(obj)
+        return _generate_class_wrapper(obj, errors=errors)
 
     # handle custom callables
-    return _generate_callable_wrapper(obj)
+    return _generate_callable_wrapper(obj, errors=errors)
 
 
-def _generate_callable_wrapper(fn: RealFunction) -> WrappedFunction:
+def _generate_callable_wrapper(fn: RealFunction, errors: ErrorBehavior) -> WrappedFunction:
     """Class decorators"""
 
     @functools.wraps(fn)
     def wrapper(*args: Any, **kwargs: Any) -> T:
-        value: T = fn(*args, **convert_kwargs_for_unpacking(kwargs, hint=fn))
+        value: T = fn(*args, **convert_kwargs_for_unpacking(kwargs, hint=fn, errors=errors))
         if hasattr(value, "__dict__"):
             value.__dict__[RAW_KEY] = kwargs
         return value
@@ -128,14 +131,14 @@ def _generate_callable_wrapper(fn: RealFunction) -> WrappedFunction:
     return wrapper
 
 
-def _generate_class_wrapper(obj: RealClass) -> WrappedClass:
+def _generate_class_wrapper(obj: RealClass, *, errors: ErrorBehavior) -> WrappedClass:
     """Function decorators"""
     fn: RealFunction = obj.__init__
 
     @functools.wraps(fn)
     def new_init(*args: Any, **kwargs: Any) -> None:
         setattr(args[0], RAW_KEY, kwargs)  # set the raw data on self
-        fn(*args, **convert_kwargs_for_unpacking(kwargs, hint=fn))
+        fn(*args, **convert_kwargs_for_unpacking(kwargs, hint=fn, errors=errors))
 
     obj.__init__ = new_init
     return obj

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -141,7 +141,8 @@ def deserialize(
     if errors == "deprecated":
         warnings.warn(
             "Please specify the error behavior when calling `flex.deserialize`. "
-            "Recommended fix: specify `errors='raise'` to catch deserialization errors. "
+            "Recommended fix: specify `errors='raise'` to catch deserialization errors. ",
+            category=DeprecationWarning,
         )
 
     if value is None:

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -115,10 +115,10 @@ def deserialize(
 
     example #1: `range` requires the `stop` argument, which is missing:
 
-        >>> deserialize({}, hint=range, errors='raise')
+        >>> deserialize({}, hint=range, errors='raise')  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         TypeError: range expected 1 argument, got 0
-        >>> deserialize({}, hint=range, errors='deprecated')
+        >>> deserialize({}, hint=range, errors='deprecated')  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         TypeError: range expected 1 argument, got 0
         >>> deserialize({}, hint=range, errors='ignore')
@@ -126,7 +126,7 @@ def deserialize(
 
     example #2: the hint is a dict, but a list was provided:
 
-        >>> deserialize([], hint=dict, errors='raise')
+        >>> deserialize([], hint=dict, errors='raise')  # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         coveo_functools.exceptions.PayloadMismatch: I don't know how to fit <class 'list'> into <class 'dict'> of typing.Any
         >>> deserialize([], hint=dict, errors='deprecated')

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -1,5 +1,6 @@
 import inspect
 import logging
+import warnings
 from collections import abc
 from enum import Enum
 from inspect import isabstract, isclass
@@ -16,6 +17,7 @@ from typing import (
     Iterable,
     Callable,
     Tuple,
+    Literal,
 )
 
 from coveo_functools.annotations import find_annotations
@@ -32,9 +34,12 @@ from coveo_functools.flex.types import TypeHint, is_passthrough_type, PASSTHROUG
 T = TypeVar("T")
 
 MetaHint = Union[Callable[..., T], SerializationMetadata, Type[T]]
+ErrorBehavior = Literal["raise", "ignore", "silent", "deprecated"]
 
 
-def convert_kwargs_for_unpacking(dirty_kwargs: Dict[str, Any], *, hint: MetaHint) -> Dict[str, Any]:
+def convert_kwargs_for_unpacking(
+    dirty_kwargs: Dict[str, Any], *, hint: MetaHint, errors: ErrorBehavior = "deprecated"
+) -> Dict[str, Any]:
     """Return a copy of `dirty_kwargs` that can be `**unpacked` to hint. Values will be deserialized recursively."""
     # start by determining what fn should be based on the hint
     additional_metadata: Dict[str, SerializationMetadata] = {}
@@ -56,22 +61,39 @@ def convert_kwargs_for_unpacking(dirty_kwargs: Dict[str, Any], *, hint: MetaHint
         if arg_name not in mapped_kwargs:
             continue  # this may be ok, for instance if the target argument has a default
 
-        converted_kwargs[arg_name] = deserialize(mapped_kwargs[arg_name], hint=arg_hint)
+        converted_kwargs[arg_name] = deserialize(
+            mapped_kwargs[arg_name], hint=arg_hint, errors=errors
+        )
 
     return converted_kwargs
 
 
 @overload
-def deserialize(value: Any, *, hint: Type[T], strict: bool = False) -> T:
+def deserialize(
+    value: Any,
+    *,
+    hint: Type[T],
+    errors: ErrorBehavior = "deprecated",
+) -> T:
     ...
 
 
 @overload
-def deserialize(value: Any, *, hint: T, strict: bool = False) -> T:
+def deserialize(
+    value: Any,
+    *,
+    hint: T,
+    errors: ErrorBehavior = "deprecated",
+) -> T:
     """This overload tricks mypy in passing typing annotations as types, such as List[str]."""
 
 
-def deserialize(value: Any, *, hint: Union[T, Type[T]], strict: bool = False) -> T:
+def deserialize(
+    value: Any,
+    *,
+    hint: Union[T, Type[T]],
+    errors: ErrorBehavior = "deprecated",
+) -> T:
     """
     Deserializes a value based on the provided type hint:
 
@@ -80,10 +102,50 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]], strict: bool = False) ->
     - If hint is a custom class, the value must be a dictionary to "flex" into the class.
     - Hint may be a `Union[T, List[T]]`, in which case the value must be a dict or a list of them.
 
-    When "strict" is True, an exception will be raised when flex cannot figure out what to do with the payload.
+    The `errors` argument controls the behavior when a value cannot be deserialized into the hint or annotation:
+        - 'ignore': the value is used as-is, without deserialization. errors will be logged.
+        - 'silent': behave like 'ignore' but don't log errors  # yolo
+        - 'raise': raise a PayloadMismatch exception.
+        - 'deprecated': (default) different situations yield different behaviors:
+            - type mismatch between value and hint (e.g.: cannot use a list to create a dict) would behave like 'ignore'
+            - value mismatch (e.g.: dict missing some arguments vs a class's __init__) would raise TypeError
+
+    Note that the `deprecated` option is currently the default, for legacy reasons. It will be removed because
+    it created an inconsistent behavior (see the examples below).
+
+    example #1: `range` requires the `stop` argument, which is missing:
+
+        >>> deserialize({}, hint=range, errors='raise')
+        Traceback (most recent call last):
+        TypeError: range expected 1 argument, got 0
+        >>> deserialize({}, hint=range, errors='deprecated')
+        Traceback (most recent call last):
+        TypeError: range expected 1 argument, got 0
+        >>> deserialize({}, hint=range, errors='ignore')
+        {}
+
+    example #2: the hint is a dict, but a list was provided:
+
+        >>> deserialize([], hint=dict, errors='raise')
+        Traceback (most recent call last):
+        coveo_functools.exceptions.PayloadMismatch: I don't know how to fit <class 'list'> into <class 'dict'> of typing.Any
+        >>> deserialize([], hint=dict, errors='deprecated')
+        []
+        >>> deserialize([], hint=dict, errors='ignore')
+        []
     """
+    valid_error_modes = "raise", "ignore", "silent", "deprecated"
+    if errors not in valid_error_modes:
+        raise ValueError(f"'{errors=}' is not valid, {valid_error_modes=}")
+
+    if errors == "deprecated":
+        warnings.warn(
+            "Please specify the error behavior when calling `flex.deserialize`. "
+            "Recommended fix: specify `errors='raise'` to catch deserialization errors. "
+        )
+
     if value is None:
-        return None  # nope!
+        return value
 
     if adapter := get_subclass_adapter(hint):
         # ask the adapter what the hint should be for this value
@@ -114,22 +176,24 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]], strict: bool = False) ->
 
         if len(args) == 1:
             # launch again with only that type
-            return cast(T, deserialize(value, hint=args[0]))
+            return cast(T, deserialize(value, hint=args[0], errors=errors))
 
         if len(args) == 2:
             # special support for variadic "thing-or-list-of-things" payloads is based on the type of the value.
             if _is_array_like(value):
-                return cast(T, deserialize(value, hint=List[target_type]))
+                return cast(T, deserialize(value, hint=List[target_type], errors=errors))
             else:
-                return cast(T, deserialize(value, hint=target_type))
+                return cast(T, deserialize(value, hint=target_type, errors=errors))
 
     try:
         if origin is list:
-            return cast(T, _deserialize(value, hint=list, contains=target_type))
+            return cast(T, _deserialize(value, hint=list, errors=errors, contains=target_type))
 
         if origin is dict:
             # json can't have maps or lists as keys, so we can't either. Ditch the key annotation, but convert values.
-            return cast(T, _deserialize(value, hint=dict, contains=args[1] if args else Any))
+            return cast(
+                T, _deserialize(value, hint=dict, errors=errors, contains=args[1] if args else Any)
+            )
 
         if is_passthrough_type(origin):
             # we always return those without validation
@@ -140,21 +204,32 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]], strict: bool = False) ->
             return cast(T, value)
 
         # annotation arguments are not supported past this point, so we can omit them.
-        return cast(T, _deserialize(value, hint=origin))
+        return cast(T, _deserialize(value, hint=origin, errors=errors))
 
-    except PayloadMismatch:
-        if strict:
+    except (PayloadMismatch, TypeError) as exception:
+        if errors == "raise":
             raise
 
-        logging.exception("An error occurred during deserialization.")
+        if errors == "deprecated" and not isinstance(exception, PayloadMismatch):
+            # legacy behavior: we did not handle these exceptions, raise it just like before.
+            raise
+
+        if errors != "silent":
+            logging.exception(
+                "An error occurred during deserialization.",
+                extra={"value": value, "origin": origin, "origin_contains": args},
+            )
+
         return value  # type: ignore[no-any-return]
 
 
 @dispatch(switch_pos="hint")
-def _deserialize(value: Any, *, hint: TypeHint, contains: Optional[TypeHint] = None) -> Any:
+def _deserialize(
+    value: Any, *, hint: TypeHint, errors: ErrorBehavior, contains: Optional[TypeHint] = None
+) -> Any:
     """Fallback deserialization; if value is dict and hint is callable, flex it. Else just return value."""
     if callable(hint) and isinstance(value, dict):
-        return hint(**convert_kwargs_for_unpacking(value, hint=hint))
+        return hint(**convert_kwargs_for_unpacking(value, hint=hint, errors=errors))
 
     raise PayloadMismatch(value, hint, contains)
 
@@ -167,6 +242,7 @@ def _deserialize_immutable(
     value: Any,
     *,
     hint: Union[Type[str], Type[int], Type[bytes], Type[float]],
+    errors: ErrorBehavior,
     contains: Optional[TypeHint] = None,
 ) -> Union[str, int, bytes, float]:
     """If the hint is a type that subclasses an immutable builtin, convert it."""
@@ -175,18 +251,24 @@ def _deserialize_immutable(
 
 
 @_deserialize.register(list)
-def _deserialize_list(value: Any, *, hint: Type[list], contains: Optional[TypeHint] = None) -> List:
+def _deserialize_list(
+    value: Any, *, hint: Type[list], errors: ErrorBehavior, contains: Optional[TypeHint] = None
+) -> List:
     """List deserialization into list of things."""
     if _is_array_like(value):
-        return [deserialize(item, hint=contains) for item in value]
+        return [deserialize(item, hint=contains, errors=errors) for item in value]
 
     raise PayloadMismatch(value, hint, contains)
 
 
 @_deserialize.register(dict)
-def _deserialize_dict(value: Any, *, hint: Type[dict], contains: Optional[TypeHint] = None) -> Dict:
+def _deserialize_dict(
+    value: Any, *, hint: Type[dict], errors: ErrorBehavior, contains: Optional[TypeHint] = None
+) -> Dict:
     if isinstance(value, abc.Mapping):
-        return {key: deserialize(val, hint=contains or Any) for key, val in value.items()}
+        return {
+            key: deserialize(val, hint=contains or Any, errors=errors) for key, val in value.items()
+        }
 
     raise PayloadMismatch(value, hint, contains)
 
@@ -196,7 +278,9 @@ def _flex_translate(string: str) -> str:
 
 
 @_deserialize.register(Enum)
-def _deserialize_enum(value: Any, *, hint: Type[Enum], contains: Optional[TypeHint] = None) -> Enum:
+def _deserialize_enum(
+    value: Any, *, hint: Type[Enum], errors: ErrorBehavior, contains: Optional[TypeHint] = None
+) -> Enum:
     try:
         # value match
         return hint(value)
@@ -229,7 +313,11 @@ def _deserialize_enum(value: Any, *, hint: Type[Enum], contains: Optional[TypeHi
 
 @_deserialize.register(SerializationMetadata)
 def _deserialize_with_metadata(
-    value: Any, *, hint: SerializationMetadata, contains: Optional[TypeHint] = None
+    value: Any,
+    *,
+    hint: SerializationMetadata,
+    errors: ErrorBehavior,
+    contains: Optional[TypeHint] = None,
 ) -> Any:
 
     if isclass(hint) and issubclass(hint, SerializationMetadata):
@@ -244,14 +332,14 @@ def _deserialize_with_metadata(
     if root_type is dict:
         # each value is converted to the type provided in the meta
         return {
-            key: deserialize(value, hint=hint.additional_metadata.get(key, value))
+            key: deserialize(value, hint=hint.additional_metadata.get(key, value), errors=errors)
             for key, value in value.items()
         }
 
     if root_type is list:
         # the value in this case is a Dict[str, SerializationMetadata] where they key is the index within the list.
         return [
-            deserialize(value[int(index)], hint=hint.additional_metadata[index])
+            deserialize(value[int(index)], hint=hint.additional_metadata[index], errors=errors)
             for index in sorted(hint.additional_metadata, key=int)
         ]
 
@@ -263,7 +351,7 @@ def _deserialize_with_metadata(
 
     if root_type is not SerializationMetadata:
         # the hint was refined this turn, we can deserialize again
-        return deserialize(value, hint=root_type)
+        return deserialize(value, hint=root_type, errors=errors)
 
     raise PayloadMismatch(value, hint, contains)
 

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -79,6 +79,8 @@ def deserialize(value: Any, *, hint: Union[T, Type[T]], strict: bool = False) ->
     - If hint is a builtin type, we blindly return the value we were given. We don't validate the value.
     - If hint is a custom class, the value must be a dictionary to "flex" into the class.
     - Hint may be a `Union[T, List[T]]`, in which case the value must be a dict or a list of them.
+
+    When "strict" is True, an exception will be raised when flex cannot figure out what to do with the payload.
     """
     if value is None:
         return None  # nope!

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -1,8 +1,11 @@
+import logging
 from dataclasses import dataclass, InitVar
 from enum import Enum
-from typing import Final, List, Any, Optional, Union, Dict, Type
+from typing import Final, List, Any, Optional, Union, Dict, Type, Tuple
 
 import pytest
+from _pytest.logging import LogCaptureFixture
+
 from coveo_testing.markers import UnitTest
 from coveo_testing.parametrize import parametrize
 
@@ -316,18 +319,60 @@ def test_deserialize_static_typing() -> None:
         _ = deserialize(fn, hint=fn)(value="") / 2  # type: ignore[operator]
 
 
-@parametrize(
-    ("payload", "hint"),
-    (
-        ([{"x": "y"}], MockType),
-        ({"x": "y"}, MockType),
-        ("x", MockType),
-        ({"x": "y"}, List[str]),
-        ({1: 2}, MockEnum),
-        (["a"], MockEnum),
-        (1, dict),
-    ),
+# the type of the payload doesn't fit the hint
+_PAYLOAD_TYPE_MISMATCH: Final[Tuple[Any, ...]] = (
+    ([{"x": "y"}], MockType),
+    ("x", MockType),
+    ({"x": "y"}, List[str]),
+    (1, dict),
 )
-def test_deserialize_wrong_type(payload: Any, hint: Any) -> None:
+
+# the type of the payload is correct but the content is wrong
+_PAYLOAD_CONTENT_MISMATCH: Final[Tuple[Any, ...]] = (
+    ({"x": "y"}, MockType),
+    ({1: 2}, MockEnum),
+    (["a"], MockEnum),
+)
+
+
+@parametrize(("payload", "hint"), _PAYLOAD_TYPE_MISMATCH + _PAYLOAD_CONTENT_MISMATCH)
+def test_deserialize_errors_raise(payload: Any, hint: Any) -> None:
     with pytest.raises(Exception):
-        _ = deserialize(payload, hint=hint, strict=True)
+        _ = deserialize(payload, hint=hint, errors="raise")
+
+
+@parametrize(("payload", "hint"), _PAYLOAD_TYPE_MISMATCH + _PAYLOAD_CONTENT_MISMATCH)
+def test_deserialize_errors_ignore(payload: Any, hint: Any, caplog: LogCaptureFixture) -> None:
+    with caplog.at_level(logging.ERROR):
+        assert deserialize(payload, hint=hint, errors="ignore") == payload
+
+    assert "Traceback" in caplog.text
+
+
+@parametrize(("payload", "hint"), _PAYLOAD_TYPE_MISMATCH + _PAYLOAD_CONTENT_MISMATCH)
+def test_deserialize_errors_silent(payload: Any, hint: Any, caplog: LogCaptureFixture) -> None:
+    with caplog.at_level(logging.ERROR):
+        assert deserialize(payload, hint=hint, errors="silent") == payload
+
+    assert "Traceback" not in caplog.text
+
+
+@parametrize(("payload", "hint"), _PAYLOAD_TYPE_MISMATCH)
+def test_deserialize_errors_deprecated_type_mismatch(
+    payload: Any, hint: Any, caplog: LogCaptureFixture
+) -> None:
+    """The legacy behavior returned the value when the type didn't match."""
+    with caplog.at_level(logging.ERROR):
+        assert deserialize(payload, hint=hint, errors="deprecated") == payload
+
+    assert "Traceback" in caplog.text
+
+
+@parametrize(("payload", "hint"), _PAYLOAD_CONTENT_MISMATCH)
+def test_deserialize_errors_deprecated_content_mismatch(
+    payload: Any, hint: Any, caplog: LogCaptureFixture
+) -> None:
+    """The legacy behavior would not handle the TypeError that occurs
+    when the value's type is correct but its content is wrong."""
+    with caplog.at_level(logging.ERROR), pytest.raises(TypeError):
+        _ = deserialize(payload, hint=hint, errors="deprecated")

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -314,3 +314,16 @@ def test_deserialize_static_typing() -> None:
 
         # mypy sees that fn returns a str, not an int
         _ = deserialize(fn, hint=fn)(value="") / 2  # type: ignore[operator]
+
+
+@parametrize(
+    ("payload", "hint"),
+    (
+        ([{"x": "y"}], MockType),
+        ({"x": "y"}, MockType),
+        ("x", MockType),
+    ),
+)
+def test_deserialize_wrong_type(payload: Any, hint: Any) -> None:
+    with pytest.raises(Exception):
+        _ = deserialize(payload, hint=hint, strict=True)

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -374,5 +374,5 @@ def test_deserialize_errors_deprecated_content_mismatch(
 ) -> None:
     """The legacy behavior would not handle the TypeError that occurs
     when the value's type is correct but its content is wrong."""
-    with caplog.at_level(logging.ERROR), pytest.raises(TypeError):
+    with pytest.raises(TypeError):
         _ = deserialize(payload, hint=hint, errors="deprecated")

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -322,6 +322,10 @@ def test_deserialize_static_typing() -> None:
         ([{"x": "y"}], MockType),
         ({"x": "y"}, MockType),
         ("x", MockType),
+        ({"x": "y"}, List[str]),
+        ({1: 2}, MockEnum),
+        (["a"], MockEnum),
+        (1, dict)
     ),
 )
 def test_deserialize_wrong_type(payload: Any, hint: Any) -> None:

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -325,7 +325,7 @@ def test_deserialize_static_typing() -> None:
         ({"x": "y"}, List[str]),
         ({1: 2}, MockEnum),
         (["a"], MockEnum),
-        (1, dict)
+        (1, dict),
     ),
 )
 def test_deserialize_wrong_type(payload: Any, hint: Any) -> None:


### PR DESCRIPTION
When strict=True and the payload can't be deserialized into the hint, raise instead of returning the value untouched.