### PR TITLE
support enum data types

### DIFF
--- a/coveo-functools/README.md
+++ b/coveo-functools/README.md
@@ -89,7 +89,7 @@ This is because `json.load()` already returns these values in the proper type. T
 Flex can be used with:
 - Classes and dataclasses
 - Abstract classes *(new in 2.0.9)* (requires adapter or serialization; explained below)
-- Enums *(new in 2.0.6)*
+- Enums *(new in 2.0.6)* *(Enum data-type support added in 2.0.26)*
 - Literals *(new in 2.0.21)*
 - Functions
 - Methods

--- a/coveo-functools/coveo_functools/flex/deserializer.py
+++ b/coveo-functools/coveo_functools/flex/deserializer.py
@@ -255,7 +255,7 @@ def _apply_error_behavior(
             )
 
 
-def _resolve_enum_data_type(enum_cls: Any) -> TypeHint:
+def _resolve_enum_data_type(enum_cls: Type[Enum]) -> TypeHint:
     """
     Resolves the type of enum values by inspecting its members.
     The documentation states that there can be up to one data type.

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -19,9 +19,14 @@ class MockType:
     value: str
 
 
-class MockEnum(Enum):
+class MockEnum(str, Enum):
     OtherKey = "other-value"
     TestKey = "test-value"
+
+
+class MockIntEnum(int, Enum):
+    OtherKey = 1
+    TestKey = 2
 
 
 DEFAULT_VALUE: Final[str] = "yup"
@@ -196,6 +201,19 @@ def test_deserialize_dict_invalid_union() -> None:
 )
 def test_deserialize_enum(value: str) -> None:
     assert deserialize(value, hint=MockEnum) is MockEnum.TestKey
+
+
+@UnitTest
+@parametrize(
+    "value",
+    (
+        "test-key",  # fish for enum name
+        "TestKey",  # fish for enum name exact match
+        2,  # exact match
+    ),
+)
+def test_deserialize_int_enum(value: str) -> None:
+    assert deserialize(value, hint=MockIntEnum) is MockIntEnum.TestKey
 
 
 @parametrize(

--- a/coveo-functools/tests_functools/test_flex_deserializer.py
+++ b/coveo-functools/tests_functools/test_flex_deserializer.py
@@ -19,7 +19,12 @@ class MockType:
     value: str
 
 
-class MockEnum(str, Enum):
+class MockEnum(Enum):
+    OtherKey = "other-value"
+    TestKey = "test-value"
+
+
+class MockStrEnum(str, Enum):
     OtherKey = "other-value"
     TestKey = "test-value"
 
@@ -191,29 +196,25 @@ def test_deserialize_dict_invalid_union() -> None:
 
 @UnitTest
 @parametrize(
-    "value",
+    ("value", "hint"),
     (
-        "test-value",  # exact value
-        "TestValue",  # fish for value
-        "test-key",  # fish for name
-        "TestKey",  # exact name
+        ("test-key", MockEnum),  # fish for enum name
+        ("TestKey", MockEnum),  # fish for enum name exact match
+        ("test-value", MockEnum),  # fish for enum value exact match
+        ("testValue", MockEnum),  # fish for enum value
+        ("test-key", MockStrEnum),  # fish for enum name
+        ("TestKey", MockStrEnum),  # fish for enum name exact match
+        ("test-value", MockStrEnum),  # fish for enum value exact match
+        ("testValue", MockStrEnum),  # fish for enum value
+        ("test-key", MockIntEnum),  # fish for enum name
+        ("TestKey", MockIntEnum),  # fish for enum name exact match
+        (2, MockIntEnum),  # exact match
     ),
 )
-def test_deserialize_enum(value: str) -> None:
-    assert deserialize(value, hint=MockEnum) is MockEnum.TestKey
-
-
-@UnitTest
-@parametrize(
-    "value",
-    (
-        "test-key",  # fish for enum name
-        "TestKey",  # fish for enum name exact match
-        2,  # exact match
-    ),
-)
-def test_deserialize_int_enum(value: str) -> None:
-    assert deserialize(value, hint=MockIntEnum) is MockIntEnum.TestKey
+def test_deserialize_enum_with_data_type(
+    value: str, hint: Union[Type[MockEnum], Type[MockIntEnum], Type[MockStrEnum]]
+) -> None:
+    assert deserialize(value, hint=hint) is hint.TestKey
 
 
 @parametrize(


### PR DESCRIPTION
This adds support for this `data-type, enum` construct:

```
class MyEnum(str, Enum): ...
```