### PR TITLE
fix hanging processes

### DIFF
--- a/coveo-systools/coveo_systools/subprocess.py
+++ b/coveo-systools/coveo_systools/subprocess.py
@@ -267,14 +267,12 @@ async def async_check_run(
     process = await asyncio.create_subprocess_exec(
         converted_command[0], *converted_command[1:], cwd=str(working_directory), **kwargs
     )
-    result = await process.wait()
-    stdout = await process.stdout.read() if process.stdout else None
-    stderr = await process.stderr.read() if process.stderr else None
+    stdout, stderr = await process.communicate()
 
-    if result != 0:
+    if process.returncode != 0:
         raise DetailedCalledProcessError(
             working_folder=working_directory
-        ) from subprocess.CalledProcessError(result, converted_command, stdout, stderr)
+        ) from subprocess.CalledProcessError(process.returncode, converted_command, stdout, stderr)
 
     return _process_output(stdout) if capture_output else None
 


### PR DESCRIPTION
The `communicate()` method adds a bunch of "noop" calls which I presume has the effect of a sleep() to give the threads some air as well as an additional `await tasks.gather()` call. Then it ends with a `process.wait()` before giving back stdout and stderr.

fixes #148 