### PR TITLE
support "on" and "off" like the old strtobool

### DIFF
--- a/coveo-settings/coveo_settings/bool_setting.py
+++ b/coveo-settings/coveo_settings/bool_setting.py
@@ -10,13 +10,13 @@ class BoolSetting(Setting[bool]):
     For instance, empty objects (strings, lists, dicts) or None will raise an exception.
     """
 
-    TRUE_VALUES = ("true", "yes", "1", "y")
-    FALSE_VALUES = ("false", "no", "0", "n")
+    TRUE_VALUES = ("true", "yes", "1", "y", "on")
+    FALSE_VALUES = ("false", "no", "0", "n", "off")
 
     @staticmethod
     def _cast(value: ConfigValue) -> bool:
         """Converts any supported value to a bool."""
-        value = str(value).lower()
+        value = str(value).casefold()
         if value not in BoolSetting.TRUE_VALUES + BoolSetting.FALSE_VALUES:
             raise ValueError(f"Cannot determine boolean from {value}")
 


### PR DESCRIPTION
The function `distutils.util.strtobool` was removed in python 3.12.

This PR adds "on" and "off" as valid values to ensure full compatibility with the aforementionned library.

[reference docs](https://docs.python.org/2/distutils/apiref.html#distutils.util.strtobool)